### PR TITLE
Update cargo install command to use --locked

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Codanna cuts the noise:
 
 ```bash
 # Install
-cargo install codanna
+cargo install codanna --locked
 
 # setup
 codanna init


### PR DESCRIPTION
Else the installation fails on mac OS.

```
   Compiling codanna v0.5.6 (/Users/bkniffler/.cargo/git/checkouts/codanna-9594e1ddd446705d/edb7b8d)
error[E0603]: struct `Parameters` is private
  --> src/mcp/mod.rs:28:55
   |
28 |     handler::server::{router::tool::ToolRouter, tool::Parameters},
   |                                                       ^^^^^^^^^^ private struct
   |
note: the struct `Parameters` is defined here
  --> /Users/bkniffler/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rmcp-0.6.1/src/handler/server/tool.rs:17:5
   |
17 |     handler::server::wrapper::Parameters,
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
help: import `Parameters` directly
   |
28 -     handler::server::{router::tool::ToolRouter, tool::Parameters},
28 +     handler::server::{router::tool::ToolRouter, rmcp::handler::server::wrapper::parameters::Parameters},
   |

warning: unused import: `std::future::Future`
  --> src/mcp/mod.rs:36:5
   |
36 | use std::future::Future;
   |     ^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default

error[E0277]: the trait bound `(Tool, ...): IntoToolRoute<..., _>` is not satisfied
   --> src/mcp/mod.rs:169:1
    |
169 | #[tool_router]
    | ^^^^^^^^^^^^^^ unsatisfied trait bound
    |
    = help: the trait `IntoToolRoute<CodeIntelligenceServer, _>` is not implemented for `(Tool, fn(&..., ...) -> ... {...::find_symbol})`
    = help: the trait `IntoToolRoute<S, A>` is implemented for `(T, C)`
note: required by a bound in `ToolRouter::<S>::with_route`
   --> /Users/bkniffler/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rmcp-0.6.1/src/handler/server/router/tool.rs:215:12
    |
213 |     pub fn with_route<R, A>(mut self, route: R) -> Self
    |            ---------- required by a bound in this associated function
214 |     where
215 |         R: IntoToolRoute<S, A>,
    |            ^^^^^^^^^^^^^^^^^^^ required by this bound in `ToolRouter::<S>::with_route`
    = note: the full name for the type has been written to '/var/folders/8s/kb3sbsmx1_v_cwkq9ffhlf1w0000gn/T/cargo-installwtpgpc/release/deps/codanna-31698a385d9413f9.long-type-9535532310814730578.txt'
    = note: consider using `--verbose` to print the full type name to the console
    = note: this error originates in the attribute macro `tool_router` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0277]: the trait bound `(Tool, ...): IntoToolRoute<..., _>` is not satisfied
   --> src/mcp/mod.rs:169:1
    |
169 | #[tool_router]
    | ^^^^^^^^^^^^^^ unsatisfied trait bound
    |
    = help: the trait `IntoToolRoute<CodeIntelligenceServer, _>` is not implemented for `(Tool, fn(&..., ...) -> ... {...::get_calls})`
    = help: the trait `IntoToolRoute<S, A>` is implemented for `(T, C)`
note: required by a bound in `ToolRouter::<S>::with_route`
   --> /Users/bkniffler/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rmcp-0.6.1/src/handler/server/router/tool.rs:215:12
    |
213 |     pub fn with_route<R, A>(mut self, route: R) -> Self
    |            ---------- required by a bound in this associated function
214 |     where
215 |         R: IntoToolRoute<S, A>,
    |            ^^^^^^^^^^^^^^^^^^^ required by this bound in `ToolRouter::<S>::with_route`
    = note: the full name for the type has been written to '/var/folders/8s/kb3sbsmx1_v_cwkq9ffhlf1w0000gn/T/cargo-installwtpgpc/release/deps/codanna-31698a385d9413f9.long-type-6821400917677620055.txt'
    = note: consider using `--verbose` to print the full type name to the console
    = note: this error originates in the attribute macro `tool_router` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0277]: the trait bound `(Tool, ...): IntoToolRoute<..., _>` is not satisfied
   --> src/mcp/mod.rs:169:1
    |
169 | #[tool_router]
    | ^^^^^^^^^^^^^^ unsatisfied trait bound
    |
    = help: the trait `IntoToolRoute<CodeIntelligenceServer, _>` is not implemented for `(Tool, fn(&..., ...) -> ... {...::find_callers})`
    = help: the trait `IntoToolRoute<S, A>` is implemented for `(T, C)`
note: required by a bound in `ToolRouter::<S>::with_route`
   --> /Users/bkniffler/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rmcp-0.6.1/src/handler/server/router/tool.rs:215:12
    |
213 |     pub fn with_route<R, A>(mut self, route: R) -> Self
    |            ---------- required by a bound in this associated function
214 |     where
215 |         R: IntoToolRoute<S, A>,
    |            ^^^^^^^^^^^^^^^^^^^ required by this bound in `ToolRouter::<S>::with_route`
    = note: the full name for the type has been written to '/var/folders/8s/kb3sbsmx1_v_cwkq9ffhlf1w0000gn/T/cargo-installwtpgpc/release/deps/codanna-31698a385d9413f9.long-type-4292582704881619643.txt'
    = note: consider using `--verbose` to print the full type name to the console
    = note: this error originates in the attribute macro `tool_router` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0277]: the trait bound `(Tool, ...): IntoToolRoute<..., _>` is not satisfied
   --> src/mcp/mod.rs:169:1
    |
169 | #[tool_router]
    | ^^^^^^^^^^^^^^ unsatisfied trait bound
    |
    = help: the trait `IntoToolRoute<CodeIntelligenceServer, _>` is not implemented for `(Tool, fn(&..., ...) -> ... {...::analyze_impact})`
    = help: the trait `IntoToolRoute<S, A>` is implemented for `(T, C)`
note: required by a bound in `ToolRouter::<S>::with_route`
   --> /Users/bkniffler/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rmcp-0.6.1/src/handler/server/router/tool.rs:215:12
    |
213 |     pub fn with_route<R, A>(mut self, route: R) -> Self
    |            ---------- required by a bound in this associated function
214 |     where
215 |         R: IntoToolRoute<S, A>,
    |            ^^^^^^^^^^^^^^^^^^^ required by this bound in `ToolRouter::<S>::with_route`
    = note: the full name for the type has been written to '/var/folders/8s/kb3sbsmx1_v_cwkq9ffhlf1w0000gn/T/cargo-installwtpgpc/release/deps/codanna-31698a385d9413f9.long-type-10734918201630184711.txt'
    = note: consider using `--verbose` to print the full type name to the console
    = note: this error originates in the attribute macro `tool_router` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0277]: the trait bound `(Tool, ...): IntoToolRoute<..., _>` is not satisfied
   --> src/mcp/mod.rs:169:1
    |
169 | #[tool_router]
    | ^^^^^^^^^^^^^^ the trait `IntoToolRoute<CodeIntelligenceServer, _>` is not implemented for `(Tool, ...)`
    |
    = help: the trait `IntoToolRoute<S, A>` is implemented for `(T, C)`
note: required by a bound in `ToolRouter::<S>::with_route`
   --> /Users/bkniffler/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rmcp-0.6.1/src/handler/server/router/tool.rs:215:12
    |
213 |     pub fn with_route<R, A>(mut self, route: R) -> Self
    |            ---------- required by a bound in this associated function
214 |     where
215 |         R: IntoToolRoute<S, A>,
    |            ^^^^^^^^^^^^^^^^^^^ required by this bound in `ToolRouter::<S>::with_route`
    = note: the full name for the type has been written to '/var/folders/8s/kb3sbsmx1_v_cwkq9ffhlf1w0000gn/T/cargo-installwtpgpc/release/deps/codanna-31698a385d9413f9.long-type-15574341789219221671.txt'
    = note: consider using `--verbose` to print the full type name to the console
    = note: this error originates in the attribute macro `tool_router` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0277]: the trait bound `(Tool, ...): IntoToolRoute<..., _>` is not satisfied
   --> src/mcp/mod.rs:169:1
    |
169 | #[tool_router]
    | ^^^^^^^^^^^^^^ the trait `IntoToolRoute<CodeIntelligenceServer, _>` is not implemented for `(Tool, ...)`
    |
    = help: the trait `IntoToolRoute<S, A>` is implemented for `(T, C)`
note: required by a bound in `ToolRouter::<S>::with_route`
   --> /Users/bkniffler/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rmcp-0.6.1/src/handler/server/router/tool.rs:215:12
    |
213 |     pub fn with_route<R, A>(mut self, route: R) -> Self
    |            ---------- required by a bound in this associated function
214 |     where
215 |         R: IntoToolRoute<S, A>,
    |            ^^^^^^^^^^^^^^^^^^^ required by this bound in `ToolRouter::<S>::with_route`
    = note: the full name for the type has been written to '/var/folders/8s/kb3sbsmx1_v_cwkq9ffhlf1w0000gn/T/cargo-installwtpgpc/release/deps/codanna-31698a385d9413f9.long-type-4104630777962995074.txt'
    = note: consider using `--verbose` to print the full type name to the console
    = note: this error originates in the attribute macro `tool_router` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0277]: the trait bound `(Tool, ...): IntoToolRoute<..., _>` is not satisfied
   --> src/mcp/mod.rs:169:1
    |
169 | #[tool_router]
    | ^^^^^^^^^^^^^^ unsatisfied trait bound
    |
    = help: the trait `IntoToolRoute<CodeIntelligenceServer, _>` is not implemented for `(Tool, fn(&..., ...) -> ... {...::search_symbols})`
    = help: the trait `IntoToolRoute<S, A>` is implemented for `(T, C)`
note: required by a bound in `ToolRouter::<S>::with_route`
   --> /Users/bkniffler/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rmcp-0.6.1/src/handler/server/router/tool.rs:215:12
    |
213 |     pub fn with_route<R, A>(mut self, route: R) -> Self
    |            ---------- required by a bound in this associated function
214 |     where
215 |         R: IntoToolRoute<S, A>,
    |            ^^^^^^^^^^^^^^^^^^^ required by this bound in `ToolRouter::<S>::with_route`
    = note: the full name for the type has been written to '/var/folders/8s/kb3sbsmx1_v_cwkq9ffhlf1w0000gn/T/cargo-installwtpgpc/release/deps/codanna-31698a385d9413f9.long-type-9840328734728114268.txt'
    = note: consider using `--verbose` to print the full type name to the console
    = note: this error originates in the attribute macro `tool_router` (in Nightly builds, run with -Z macro-backtrace for more info)

Some errors have detailed explanations: E0277, E0603.
For more information about an error, try `rustc --explain E0277`.
warning: `codanna` (lib) generated 1 warning
error: could not compile `codanna` (lib) due to 8 previous errors; 1 warning emitted
warning: build failed, waiting for other jobs to finish...
error: failed to compile `codanna v0.5.6 (https://github.com/bartolli/codanna#edb7b8dc)`, intermediate artifacts can be found at `/var/folders/8s/kb3sbsmx1_v_cwkq9ffhlf1w0000gn/T/cargo-installwtpgpc`.
To reuse those artifacts with a future compilation, set the environment variable `CARGO_TARGET_DIR` to that path.
```