### PR TITLE
External Type Tracking for C#

### DIFF
--- a/docs/architecture/language-support.md
+++ b/docs/architecture/language-support.md
@@ -37,6 +37,7 @@ From each supported language:
 - Call relationships
 - Type relationships
 - Documentation comments
+- External type references (for compiled languages like C# and Java)
 
 ## Performance
 

--- a/docs/integrations/agent-guidance.md
+++ b/docs/integrations/agent-guidance.md
@@ -16,6 +16,14 @@ Workflow:
 3. find_symbol, get_calls, find_callers - Get specific details
 
 Start with semantic search, then narrow with specific queries.
+
+### Understanding ExternalType Symbols
+
+For compiled languages (C#, Java), Codanna tracks references to external types from libraries/assemblies even though their definitions aren't in your source code.
+
+- **ExternalType** symbols represent types from external dependencies (NuGet packages, DLLs, JARs)
+- When you find an ExternalType, use `search_symbols` to find all usages across your codebase
+- These are references only - the actual type definition is in an external library
 ```
 
 ## Claude Sub Agent

--- a/docs/user-guide/mcp-tools.md
+++ b/docs/user-guide/mcp-tools.md
@@ -33,7 +33,7 @@ codanna mcp find_symbol main
 codanna mcp find_symbol Parser --json
 ```
 
-**Returns:** Symbol information including file path, line number, kind, and signature.
+**Returns:** Symbol information including file path, line number, kind, and signature. For ExternalType symbols (types from external assemblies/libraries), includes a helpful note explaining they're not defined in source code.
 
 ### `search_symbols`
 
@@ -42,7 +42,7 @@ Search symbols with full-text fuzzy matching.
 **Parameters:**
 - `query` (required) - Search query (supports fuzzy matching)
 - `limit` - Maximum number of results (default: 10)
-- `kind` - Filter by symbol kind (e.g., "Function", "Struct", "Trait")
+- `kind` - Filter by symbol kind (e.g., "Function", "Struct", "Trait", "ExternalType")
 - `module` - Filter by module path
 
 **Example:**

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -290,6 +290,15 @@ impl CodeIntelligenceServer {
                     result.push_str(&format!("Signature: {sig}\n"));
                 }
 
+                // Add note for external types
+                if symbol.kind == crate::SymbolKind::ExternalType {
+                    result.push_str("\nNote: This type is not defined in your source code. ");
+                    result.push_str("It's from an external assembly/library.\n");
+                    result.push_str(
+                        "Use 'search_symbols' to find all usages of this type in your codebase.\n",
+                    );
+                }
+
                 // Add documentation preview
                 if let Some(doc) = symbol.as_doc_comment() {
                     let doc_preview: Vec<&str> = doc.lines().take(3).collect();

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -57,6 +57,10 @@ pub enum SymbolKind {
     Parameter,
     TypeAlias,
     Macro,
+    /// External type reference (not defined in source code)
+    /// Used primarily for tracking references to types from external assemblies/libraries
+    /// in compiled languages like C# and Java
+    ExternalType,
 }
 
 impl SymbolId {
@@ -135,6 +139,7 @@ impl FromStr for SymbolKind {
             "Parameter" => Ok(SymbolKind::Parameter),
             "TypeAlias" => Ok(SymbolKind::TypeAlias),
             "Macro" => Ok(SymbolKind::Macro),
+            "ExternalType" => Ok(SymbolKind::ExternalType),
             _ => Err("Unknown symbol kind"),
         }
     }
@@ -216,9 +221,10 @@ mod tests {
             SymbolKind::Parameter,
             SymbolKind::TypeAlias,
             SymbolKind::Macro,
+            SymbolKind::ExternalType,
         ];
 
-        assert_eq!(kinds.len(), 14);
+        assert_eq!(kinds.len(), 15);
     }
 
     #[test]

--- a/src/vector/embedding.rs
+++ b/src/vector/embedding.rs
@@ -531,6 +531,7 @@ pub fn create_symbol_text(
         crate::types::SymbolKind::Class => "class",
         crate::types::SymbolKind::Field => "field",
         crate::types::SymbolKind::Parameter => "parameter",
+        crate::types::SymbolKind::ExternalType => "external_type",
     };
 
     if let Some(sig) = signature {


### PR DESCRIPTION
When working with C# codebases, users frequently search for types that are defined in external assemblies (DLLs, NuGet packages) rather than in source code. Currently, Codanna returns "No symbols found" for these types, which is confusing because:

1. The types ARE used extensively in the codebase
2. Users can see them in their IDE and code
3. The error message doesn't explain WHY they're not found

### Example

```csharp
public class EventProcessor {
    DataTransferObject _cachedDataA;  // DataTransferObject is from external assembly
    DataTransferObject _cachedDataB;
}
```

**Before this PR:**
```
codanna retrieve symbol DataTransferObject
→ symbol not found
```

**After this PR:**
```
codanna retrieve symbol DataTransferObject
→ DataTransferObject (ExternalType) at EventProcessor.cs:21
   Signature: external type: DataTransferObject

   Note: This type is not defined in your source code.
   It's from an external assembly/library.
   Use 'search_symbols' to find all usages of this type in your codebase.
```

## Solution

Add **external type tracking** specifically for C#, with a design that can be extended to other compiled languages (Java, etc.).

### Key Features

1. **Distinguish local vs. external types**
   - Track all types defined in source code (classes, interfaces, structs, enums, records)
   - Detect when a type reference is NOT locally defined

2. **Smart filtering**
   - Skip primitive types (`int`, `string`, `bool`, etc.)
   - Skip well-known framework types (`String`, `Int32`, `Object`, etc.)
   - Only track user-defined external types

3. **Clear communication**
   - New `SymbolKind::ExternalType` makes it explicit
   - Helpful MCP tool messages guide users
   - Signature includes "external type:" prefix

## Implementation Details

### 1. New Symbol Kind (`src/types/mod.rs`)

```rust
pub enum SymbolKind {
    // ... existing variants ...
    /// External type reference (not defined in source code)
    /// Used primarily for tracking references to types from external assemblies/libraries
    /// in compiled languages like C# and Java
    ExternalType,
}
```

### 2. C# Parser Changes (`src/parsing/csharp/parser.rs`)

**Added tracking infrastructure:**
```rust
pub struct CSharpParser {
    // ... existing fields ...
    local_types: HashSet<String>,
    external_type_refs: HashMap<String, Option<String>>,
}
```

**Modified type processing methods:**
- `process_class`, `process_interface`, `process_struct`, `process_enum`, `process_record`
  - All now call `record_local_type()` to track definitions

**Added external type detection:**
- `process_field_declaration` now extracts type references
- Checks if type is local, primitive, or external
- Creates ExternalType symbol for genuine external references

### 3. MCP Tool Enhancement (`src/mcp/mod.rs`)

```rust
if symbol.kind == crate::SymbolKind::ExternalType {
    result.push_str("\nNote: This type is not defined in your source code. ");
    result.push_str("It's from an external assembly/library.\n");
    result.push_str("Use 'search_symbols' to find all usages of this type in your codebase.\n");
}
```

## Testing

### Test Case: External NuGet Package Type

**Code:**
```csharp
using Company.Product.DataMapper.Model;

public class EventProcessor : IEventProcessor
{
    DataTransferObject _cachedDataA;
    DataTransferObject _cachedDataB;

    public DataTransferObject ProcessedData { get; set; }
}
```

**Result:**
```bash
$ codanna retrieve symbol DataTransferObject
DataTransferObject (ExternalType) at EventProcessor.cs:21 [symbol_id:80]
Module: Company.Product.ServiceLayer...
Signature: external type: DataTransferObject
Visibility: Public

Note: This type is not defined in your source code.
It's from an external assembly/library.
Use 'search_symbols' to find all usages of this type in your codebase.
```

## Impact

- ✅ Fixes confusion about missing symbols
- ✅ Improves C# developer experience significantly
- ✅ Provides actionable guidance (use `search_symbols`)
- ✅ Foundation for Java and other compiled language support

## Documentation Updates

- Updated `docs/architecture/language-support.md` to document external type tracking
- Updated `docs/user-guide/mcp-tools.md` with ExternalType kind information
- Updated `docs/integrations/agent-guidance.md` with guidance for AI agents on handling external types
