### PR TITLE
docs: 主要なモジュールに日本語のrustdocコメントを追加

### DIFF
--- a/src/display/mod.rs
+++ b/src/display/mod.rs
@@ -1,7 +1,22 @@
-//! Rich terminal display utilities for enhanced CLI output.
+//! リッチターミナルディスプレイユーティリティ
 //!
-//! Provides styled tables, progress bars, and formatted output
-//! for a professional command-line experience.
+//! 強化されたCLI出力のためのスタイル付きテーブル、プログレスバー、
+//! フォーマット済み出力を提供します。プロフェッショナルなコマンドライン体験を実現します。
+//!
+//! # 主要なコンポーネント
+//!
+//! - スタイル付きテーブル
+//! - プログレスバー
+//! - テーマサポート
+//! - ヘルプテキストフォーマット
+//!
+//! # 使用例
+//!
+//! ```no_run
+//! // use codanna::display::theme::Theme;
+//! // let theme = Theme::default();
+//! // println!("{}", theme.success("成功しました！"));
+//! ```
 
 pub mod help;
 pub mod progress;

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,29 +1,72 @@
-//! Error types for the codebase intelligence system
+//! エラー型定義モジュール
 //!
-//! This module provides structured error types using thiserror for better
-//! error handling and actionable error messages.
+//! このモジュールは、コードベースインテリジェンスシステムで使用される
+//! 構造化されたエラー型を提供します。`thiserror`クレートを使用して、
+//! より良いエラーハンドリングと実用的なエラーメッセージを実現しています。
+//!
+//! # 主なエラー型
+//!
+//! - [`IndexError`]: インデックス操作に関するエラー
+//! - [`ParseError`]: パース操作に関するエラー
+//! - [`StorageError`]: ストレージ操作に関するエラー
+//! - [`McpError`]: MCP操作に関するエラー
+//!
+//! # 使用例
+//!
+//! ```
+//! use codanna::error::{IndexError, IndexResult};
+//! use std::path::PathBuf;
+//!
+//! fn example_operation() -> IndexResult<()> {
+//!     // エラーを返す例
+//!     Err(IndexError::ConfigError {
+//!         reason: "設定ファイルが見つかりません".to_string()
+//!     })
+//! }
+//! ```
 
 use crate::{FileId, SymbolId};
 use std::path::PathBuf;
 use thiserror::Error;
 
-/// Main error type for indexing operations
+/// インデックス操作のメインエラー型
+///
+/// インデックス作成、読み込み、永続化などの操作で発生する
+/// 各種エラーを表現します。
+///
+/// # 使用例
+///
+/// ```
+/// use codanna::error::IndexError;
+/// use std::path::PathBuf;
+///
+/// let error = IndexError::ConfigError {
+///     reason: "無効な設定".to_string()
+/// };
+///
+/// // エラーコードを取得
+/// assert_eq!(error.status_code(), "CONFIG_ERROR");
+///
+/// // リカバリの提案を取得
+/// let suggestions = error.recovery_suggestions();
+/// ```
 #[derive(Error, Debug)]
 pub enum IndexError {
-    /// File system errors
+    /// ファイルシステムエラー - ファイル読み込み失敗
     #[error("Failed to read file '{path}': {source}")]
     FileRead {
         path: PathBuf,
         source: std::io::Error,
     },
 
+    /// ファイルシステムエラー - ファイル書き込み失敗
     #[error("Failed to write file '{path}': {source}")]
     FileWrite {
         path: PathBuf,
         source: std::io::Error,
     },
 
-    /// Parsing errors
+    /// パースエラー - 言語固有のパース失敗
     #[error("Failed to parse {language} file '{path}': {reason}")]
     ParseError {
         path: PathBuf,
@@ -31,71 +74,90 @@ pub enum IndexError {
         reason: String,
     },
 
+    /// サポートされていないファイルタイプ
     #[error(
         "Unsupported file type '{extension}' for file '{path}'. Supported types: .rs, .go, .py, .js, .ts, .java"
     )]
     UnsupportedFileType { path: PathBuf, extension: String },
 
-    /// Storage errors
+    /// ストレージエラー - インデックスの永続化失敗
     #[error("Failed to persist index to '{path}': {source}")]
     PersistenceError {
         path: PathBuf,
         source: Box<dyn std::error::Error + Send + Sync>,
     },
 
+    /// ストレージエラー - インデックスの読み込み失敗
     #[error("Failed to load index from '{path}': {source}")]
     LoadError {
         path: PathBuf,
         source: Box<dyn std::error::Error + Send + Sync>,
     },
 
-    /// Symbol resolution errors
+    /// シンボル解決エラー - シンボルが見つからない
     #[error("Symbol '{name}' not found. Did you mean to index the file first?")]
     SymbolNotFound { name: String },
 
+    /// シンボル解決エラー - ファイルIDが見つからない
     #[error("File ID {id:?} not found in index. The file may have been removed or not indexed.")]
     FileNotFound { id: FileId },
 
-    /// Index state errors
+    /// インデックス状態エラー - ファイルIDの上限到達
     #[error("Failed to create file ID: maximum file count reached")]
     FileIdExhausted,
 
+    /// インデックス状態エラー - シンボルIDの上限到達
     #[error("Failed to create symbol ID: maximum symbol count reached")]
     SymbolIdExhausted,
 
-    /// Configuration errors
+    /// 設定エラー - 無効な設定
     #[error("Invalid configuration: {reason}")]
     ConfigError { reason: String },
 
-    /// Tantivy-specific errors
+    /// Tantivy固有のエラー
     #[error("Tantivy operation failed during {operation}: {cause}")]
     TantivyError { operation: String, cause: String },
 
-    /// Transaction errors
+    /// トランザクションエラー - トランザクション失敗
     #[error("Transaction failed after operations: {operations:?}. Cause: {cause}")]
     TransactionFailed {
         operations: Vec<String>,
         cause: String,
     },
 
-    /// Mutex poisoned error
+    /// Mutexポイズンエラー - 別スレッドでのパニックによる
     #[error("Internal mutex was poisoned, likely due to panic in another thread")]
     MutexPoisoned,
 
-    /// Corrupted index error
+    /// 破損したインデックスエラー
     #[error("Index appears to be corrupted: {reason}")]
     IndexCorrupted { reason: String },
 
-    /// General errors for cases where we need to preserve existing behavior
+    /// 一般的なエラー - 既存の動作を保持するため
     #[error("{0}")]
     General(String),
 }
 
 impl IndexError {
-    /// Get a stable status code for this error type.
+    /// このエラー型の安定したステータスコードを取得します
     ///
-    /// Returns a string identifier that can be used in JSON responses
-    /// for programmatic error handling.
+    /// プログラマティックなエラーハンドリングのためにJSON レスポンスで
+    /// 使用できる文字列識別子を返します。
+    ///
+    /// # 戻り値
+    ///
+    /// エラーの種類を表す文字列（例: "CONFIG_ERROR", "FILE_NOT_FOUND"）
+    ///
+    /// # 使用例
+    ///
+    /// ```
+    /// use codanna::error::IndexError;
+    ///
+    /// let error = IndexError::ConfigError {
+    ///     reason: "無効な設定".to_string()
+    /// };
+    /// assert_eq!(error.status_code(), "CONFIG_ERROR");
+    /// ```
     pub fn status_code(&self) -> String {
         match self {
             Self::FileRead { .. } => "FILE_READ_ERROR",
@@ -118,7 +180,25 @@ impl IndexError {
         .to_string()
     }
 
-    /// Get recovery suggestions for this error
+    /// このエラーのリカバリ提案を取得します
+    ///
+    /// エラーから回復するための具体的な提案のリストを返します。
+    ///
+    /// # 戻り値
+    ///
+    /// 回復方法を説明する文字列のベクタ
+    ///
+    /// # 使用例
+    ///
+    /// ```
+    /// use codanna::error::IndexError;
+    ///
+    /// let error = IndexError::IndexCorrupted {
+    ///     reason: "破損したデータ".to_string()
+    /// };
+    /// let suggestions = error.recovery_suggestions();
+    /// assert!(!suggestions.is_empty());
+    /// ```
     pub fn recovery_suggestions(&self) -> Vec<&'static str> {
         match self {
             Self::TantivyError { .. } => vec![
@@ -154,12 +234,27 @@ impl IndexError {
     }
 }
 
-/// Errors specific to parsing operations
+/// パース操作固有のエラー
+///
+/// ソースコードのパース中に発生するエラーを表現します。
+///
+/// # 使用例
+///
+/// ```
+/// use codanna::error::ParseError;
+///
+/// let error = ParseError::ParserInit {
+///     language: "Rust".to_string(),
+///     reason: "パーサーの初期化に失敗".to_string(),
+/// };
+/// ```
 #[derive(Error, Debug)]
 pub enum ParseError {
+    /// パーサー初期化エラー
     #[error("Failed to initialize {language} parser: {reason}")]
     ParserInit { language: String, reason: String },
 
+    /// 構文エラー - 特定の行と列で発生
     #[error("Failed to parse code at line {line}, column {column}: {reason}")]
     SyntaxError {
         line: u32,
@@ -167,55 +262,118 @@ pub enum ParseError {
         reason: String,
     },
 
+    /// 無効なUTF-8エンコーディング
     #[error("Invalid UTF-8 in source file")]
     InvalidUtf8,
 }
 
-/// Errors specific to storage operations
+/// ストレージ操作固有のエラー
+///
+/// インデックスの永続化や検索エンジン操作で発生するエラーを表現します。
+///
+/// # 使用例
+///
+/// ```
+/// use codanna::error::StorageError;
+///
+/// let error = StorageError::DatabaseError(
+///     "接続エラー".to_string()
+/// );
+/// ```
 #[derive(Error, Debug)]
 pub enum StorageError {
+    /// Tantivyインデックスエラー
     #[error("Tantivy index error: {0}")]
     TantivyError(#[from] tantivy::TantivyError),
 
+    /// データベースエラー
     // Removed bincode error variant - no longer needed with Tantivy-only architecture
     #[error("Database error: {0}")]
     DatabaseError(String),
 
+    /// ドキュメント未検出エラー
     #[error("Document not found for symbol {id:?}")]
     DocumentNotFound { id: SymbolId },
 }
 
-/// Errors specific to MCP operations
+/// MCP操作固有のエラー
+///
+/// Model Context Protocol (MCP) サーバーやクライアント操作で発生するエラーを表現します。
+///
+/// # 使用例
+///
+/// ```
+/// use codanna::error::McpError;
+///
+/// let error = McpError::ServerInitError {
+///     reason: "ポートが使用中です".to_string()
+/// };
+/// ```
 #[derive(Error, Debug)]
 pub enum McpError {
+    /// MCPサーバー初期化エラー
     #[error("Failed to initialize MCP server: {reason}")]
     ServerInitError { reason: String },
 
+    /// MCPクライアントエラー
     #[error("MCP client error: {reason}")]
     ClientError { reason: String },
 
+    /// 無効なツール引数エラー
     #[error("Invalid tool arguments: {reason}")]
     InvalidArguments { reason: String },
 }
 
-/// Result type alias for index operations
+/// インデックス操作用の Result 型エイリアス
+///
+/// # 使用例
+///
+/// ```
+/// use codanna::error::{IndexResult, IndexError};
+///
+/// fn example_function() -> IndexResult<String> {
+///     Ok("成功".to_string())
+/// }
+/// ```
 pub type IndexResult<T> = Result<T, IndexError>;
 
-/// Result type alias for parse operations
+/// パース操作用の Result 型エイリアス
 pub type ParseResult<T> = Result<T, ParseError>;
 
-/// Result type alias for storage operations
+/// ストレージ操作用の Result 型エイリアス
 pub type StorageResult<T> = Result<T, StorageError>;
 
-/// Result type alias for MCP operations
+/// MCP操作用の Result 型エイリアス
 pub type McpResult<T> = Result<T, McpError>;
 
-/// Helper trait for adding context to errors
+/// エラーにコンテキストを追加するためのヘルパートレイト
+///
+/// エラーメッセージにコンテキスト情報を追加して、より詳細なエラー情報を提供します。
+///
+/// # 使用例
+///
+/// ```
+/// use codanna::error::{ErrorContext, IndexResult};
+/// use std::fs;
+///
+/// fn read_config() -> IndexResult<String> {
+///     fs::read_to_string("/path/to/config.toml")
+///         .context("設定ファイルの読み込みに失敗しました")
+/// }
+/// ```
 pub trait ErrorContext<T> {
-    /// Add context to an error
+    /// エラーにコンテキストメッセージを追加します
+    ///
+    /// # 引数
+    ///
+    /// * `msg` - 追加するコンテキストメッセージ
     fn context(self, msg: &str) -> Result<T, IndexError>;
 
-    /// Add context with a path
+    /// エラーにパス情報を追加します
+    ///
+    /// # 引数
+    ///
+    /// * `path` - エラーに関連するファイルパス
     fn with_path(self, path: &std::path::Path) -> Result<T, IndexError>;
 }
 

--- a/src/indexing/mod.rs
+++ b/src/indexing/mod.rs
@@ -1,3 +1,25 @@
+//! インデックス作成モジュール
+//!
+//! コードベースのインデックス化、ファイル監視、進捗追跡などの機能を提供します。
+//!
+//! # 主要なコンポーネント
+//!
+//! - [`SimpleIndexer`]: メインのインデクサー実装
+//! - [`FileWalker`]: ファイルシステムの探索
+//! - [`FileSystemWatcher`]: ファイル変更の監視
+//! - [`IndexTransaction`]: トランザクション管理
+//! - [`ConfigFileWatcher`]: 設定ファイルの監視
+//!
+//! # 使用例
+//!
+//! ```no_run
+//! use codanna::indexing::SimpleIndexer;
+//! use codanna::Settings;
+//!
+//! let settings = Settings::default();
+//! let indexer = SimpleIndexer::new(&settings);
+//! ```
+
 pub mod config_watcher;
 pub mod file_info;
 pub mod fs_watcher;

--- a/src/init.rs
+++ b/src/init.rs
@@ -1,9 +1,29 @@
-//! Global initialization module for Codanna
+//! グローバル初期化モジュール
 //!
-//! Manages:
-//! - Global models directory for FastEmbed
-//! - Project registry
-//! - Symlink creation for model cache
+//! Codannaのグローバルディレクトリ構造とプロジェクトレジストリを管理します。
+//!
+//! # 管理対象
+//!
+//! - FastEmbed用のグローバルモデルディレクトリ
+//! - プロジェクトレジストリ
+//! - モデルキャッシュ用のシンボリックリンク作成
+//!
+//! # 使用例
+//!
+//! ```no_run
+//! use codanna::init::{init_global_dirs, global_dir, models_dir};
+//!
+//! // グローバルディレクトリを初期化
+//! init_global_dirs().expect("初期化に失敗しました");
+//!
+//! // グローバルディレクトリのパスを取得
+//! let dir = global_dir();
+//! println!("グローバルディレクトリ: {:?}", dir);
+//!
+//! // モデルディレクトリのパスを取得
+//! let models = models_dir();
+//! println!("モデルディレクトリ: {:?}", models);
+//! ```
 
 use crate::error::IndexError;
 use serde::{Deserialize, Serialize};

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -1,9 +1,28 @@
-//! Input/Output handling for CLI and tool integration.
+//! 入出力処理モジュール
 //!
-//! This module provides:
-//! - Unified output formatting (text, JSON)
-//! - Consistent error handling and exit codes
-//! - Future: JSON-RPC 2.0 support for IDE integration
+//! CLIとツール統合のための入出力処理を提供します。
+//!
+//! # 主な機能
+//!
+//! - 統一された出力フォーマット（テキスト、JSON）
+//! - 一貫性のあるエラーハンドリングと終了コード
+//! - 将来: IDE統合のためのJSON-RPC 2.0サポート
+//!
+//! # 主要なコンポーネント
+//!
+//! - [`OutputFormat`]: 出力フォーマット（Text, JSON）
+//! - [`OutputManager`]: 出力管理
+//! - [`ExitCode`]: 終了コード
+//! - [`UnifiedOutput`]: 統一出力スキーマ
+//!
+//! # 使用例
+//!
+//! ```
+//! use codanna::io::{OutputFormat, OutputManager};
+//!
+//! let mut output = OutputManager::new(OutputFormat::Json);
+//! // output.success("操作が成功しました");
+//! ```
 
 pub mod args;
 pub mod exit_code;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,52 @@
-/// The main library module for codanna
+//! # Codanna
+//!
+//! Codannaは、コードベースの解析とインデックス化を行うためのライブラリです。
+//! 複数のプログラミング言語に対応し、シンボル解析、セマンティック検索、
+//! ベクトル埋め込みなどの機能を提供します。
+//!
+//! ## 主な機能
+//!
+//! - **マルチ言語パーサー**: Rust, Python, TypeScript, Kotlin, Go などをサポート
+//! - **シンボル解析**: 関数、構造体、クラスなどのシンボルを抽出
+//! - **セマンティック検索**: コードの意味的な検索機能
+//! - **ベクトル埋め込み**: コードのベクトル表現を生成
+//! - **プラグインシステム**: 拡張可能なアーキテクチャ
+//!
+//! ## 使用例
+//!
+//! ```no_run
+//! use codanna::{Settings, SimpleIndexer};
+//!
+//! // 設定を読み込む
+//! let settings = Settings::default();
+//!
+//! // インデクサーを作成
+//! let indexer = SimpleIndexer::new(&settings);
+//! ```
+
 // Alias for tree-sitter-kotlin dependency
 // When upstream publishes 0.3.9+, change Cargo.toml and update this line:
 // extern crate tree_sitter_kotlin;
 extern crate tree_sitter_kotlin_codanna as tree_sitter_kotlin;
 
-// Debug macro for consistent debug output
+/// デバッグ出力を行うマクロ
+///
+/// グローバルなデバッグフラグが有効な場合のみ、標準エラー出力にメッセージを出力します。
+///
+/// # 引数
+///
+/// * `$self` - デバッグ出力を行うコンテキスト（未使用だが互換性のため保持）
+/// * `$($arg:tt)*` - フォーマット文字列と引数
+///
+/// # 使用例
+///
+/// ```
+/// # #[macro_use] extern crate codanna;
+/// # fn main() {
+/// # let context = ();
+/// debug_print!(context, "変数の値: {}", 42);
+/// # }
+/// ```
 #[macro_export]
 macro_rules! debug_print {
     ($self:expr, $($arg:tt)*) => {

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -1,21 +1,28 @@
-//! MCP (Model Context Protocol) server implementation for code intelligence
+//! MCP (Model Context Protocol) サーバー実装モジュール
 //!
-//! This module provides MCP tools that allow AI assistants to query
-//! the code intelligence index.
+//! このモジュールは、AIアシスタントがコードインテリジェンスインデックスを
+//! クエリできるようにするMCPツールを提供します。
 //!
-//! ## Architecture
+//! # アーキテクチャ
 //!
-//! The MCP server can run in two modes:
+//! MCPサーバーは2つのモードで実行できます：
 //!
-//! 1. **Standalone Server Mode**: Run with `cargo run -- serve`
-//!    - Loads index once into memory
-//!    - Listens for client connections via stdio
-//!    - Efficient for production use with AI assistants
+//! 1. **スタンドアロンサーバーモード**: `cargo run -- serve` で実行
+//!    - インデックスを一度メモリにロード
+//!    - stdioを介してクライアント接続をリッスン
+//!    - AIアシスタントとの本番使用に効率的
 //!
-//! 2. **Embedded Mode**: Used by the CLI directly
-//!    - No separate process needed
-//!    - Direct access to already-loaded index
-//!    - Most memory efficient for CLI operations
+//! 2. **埋め込みモード**: CLIから直接使用
+//!    - 別プロセス不要
+//!    - 既にロードされたインデックスへの直接アクセス
+//!    - CLI操作に最もメモリ効率的
+//!
+//! # 使用例
+//!
+//! ```no_run
+//! // サーバーモードでの起動
+//! // cargo run -- serve --stdio
+//! ```
 
 pub mod client;
 pub mod http_server;

--- a/src/parsing/mod.rs
+++ b/src/parsing/mod.rs
@@ -1,3 +1,36 @@
+//! パーシングモジュール
+//!
+//! 複数のプログラミング言語のパーサーと言語固有の動作を提供します。
+//!
+//! # サポート言語
+//!
+//! - Rust
+//! - Python
+//! - TypeScript / JavaScript
+//! - Go
+//! - Kotlin
+//! - C / C++
+//! - C#
+//! - PHP
+//! - GDScript
+//!
+//! # 主要なコンポーネント
+//!
+//! - [`LanguageParser`]: パーサートレイト
+//! - [`LanguageBehavior`]: 言語固有の動作
+//! - [`ParserFactory`]: パーサーのファクトリ
+//! - [`LanguageRegistry`]: 言語登録システム
+//!
+//! # 使用例
+//!
+//! ```no_run
+//! use codanna::parsing::{RustParser, LanguageParser};
+//!
+//! let parser = RustParser;
+//! let source = "fn main() {}";
+//! // let symbols = parser.parse(source, file_id);
+//! ```
+
 pub mod behavior_state;
 pub mod c;
 pub mod context;

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -1,7 +1,22 @@
-//! Plugin management system for Claude Code plugins
+//! プラグイン管理システム
 //!
-//! This module provides functionality for installing, updating, and managing
-//! Claude Code plugins from Git-based marketplaces.
+//! Claude Code プラグインのインストール、更新、管理機能を提供します。
+//! Gitベースのマーケットプレイスからプラグインを取得できます。
+//!
+//! # 主要な機能
+//!
+//! - プラグインのインストールと更新
+//! - マーケットプレイスからの解決
+//! - ロックファイル管理
+//! - プラグインのマージ
+//!
+//! # 使用例
+//!
+//! ```no_run
+//! // use codanna::plugins::marketplace::MarketplaceResolver;
+//! // let resolver = MarketplaceResolver::new();
+//! // resolver.install_plugin("my-plugin");
+//! ```
 
 pub mod error;
 pub mod fsops;

--- a/src/profiles/mod.rs
+++ b/src/profiles/mod.rs
@@ -1,4 +1,22 @@
-//! Profile system for project initialization
+//! プロファイルシステム
+//!
+//! プロジェクト初期化のためのプロファイルシステムを提供します。
+//! テンプレートベースのプロジェクトセットアップを可能にします。
+//!
+//! # 主要な機能
+//!
+//! - プロファイルのインストールと管理
+//! - プロジェクトマニフェストの処理
+//! - ロックファイル管理
+//! - ローカルオーバーライド
+//!
+//! # 使用例
+//!
+//! ```no_run
+//! // use codanna::profiles::installer::ProfileInstaller;
+//! // let installer = ProfileInstaller::new();
+//! // installer.install_profile("typescript-project");
+//! ```
 
 pub mod commands;
 pub mod error;

--- a/src/project_resolver/mod.rs
+++ b/src/project_resolver/mod.rs
@@ -1,11 +1,23 @@
-//! Cross-language project configuration resolver (Sprint 0)
+//! クロスランゲージプロジェクト設定リゾルバ
 //!
-//! Resolves project-level configuration files (tsconfig.json, pyproject.toml, go.mod, etc.)
-//! to determine module resolution rules, import paths, and project-specific settings.
+//! プロジェクトレベルの設定ファイル (tsconfig.json, pyproject.toml, go.mod など) を解決して、
+//! モジュール解決ルール、インポートパス、プロジェクト固有の設定を決定します。
 //!
-//! This is distinct from `parsing::resolution` which handles symbol resolution within code.
-//! - project_resolver: "What tsconfig.json applies to this file?"
-//! - parsing::resolution: "What does the identifier 'foo' refer to in this scope?"
+//! これは `parsing::resolution` とは異なり、コード内のシンボル解決ではなく、
+//! プロジェクト設定の解決を担当します。
+//!
+//! # 役割の違い
+//!
+//! - `project_resolver`: "このファイルにはどのtsconfig.jsonが適用されるか？"
+//! - `parsing::resolution`: "このスコープで識別子 'foo' は何を参照するか？"
+//!
+//! # 使用例
+//!
+//! ```no_run
+//! // use codanna::project_resolver::registry::SimpleProviderRegistry;
+//! // let registry = SimpleProviderRegistry::new();
+//! // let config = registry.resolve_config(file_path);
+//! ```
 
 pub mod memo;
 pub mod persist;

--- a/src/relationship/mod.rs
+++ b/src/relationship/mod.rs
@@ -1,3 +1,22 @@
+//! リレーションシップモジュール
+//!
+//! シンボル間の関係（呼び出し、継承、実装など）を表現します。
+//!
+//! # 主要な型
+//!
+//! - [`RelationKind`]: 関係の種類
+//! - [`Relationship`]: シンボル間の関係
+//! - [`RelationshipEdge`]: 関係のエッジ表現
+//!
+//! # 使用例
+//!
+//! ```
+//! use codanna::relationship::RelationKind;
+//!
+//! let kind = RelationKind::Calls;
+//! assert_eq!(kind, RelationKind::Calls);
+//! ```
+
 use crate::types::SymbolId;
 use serde::{Deserialize, Serialize};
 

--- a/src/retrieve.rs
+++ b/src/retrieve.rs
@@ -1,4 +1,23 @@
-//! Retrieve command implementations using UnifiedOutput schema
+//! シンボル取得コマンドの実装
+//!
+//! UnifiedOutput スキーマを使用してシンボルを検索・取得する機能を提供します。
+//!
+//! # 主な機能
+//!
+//! - 名前によるシンボル検索
+//! - シンボルIDによる直接取得
+//! - 言語フィルタリング
+//! - 統一された出力フォーマット
+//!
+//! # 使用例
+//!
+//! ```no_run
+//! use codanna::{SimpleIndexer, retrieve::retrieve_symbol};
+//! use codanna::io::OutputFormat;
+//!
+//! let indexer = SimpleIndexer::default();
+//! retrieve_symbol(&indexer, "my_function", Some("rust"), OutputFormat::Json);
+//! ```
 
 use crate::io::{
     EntityType, ExitCode, OutputFormat, OutputManager, OutputStatus,

--- a/src/semantic/mod.rs
+++ b/src/semantic/mod.rs
@@ -1,7 +1,23 @@
-//! Semantic search functionality for documentation comments
+//! セマンティック検索モジュール
 //!
-//! This module provides a simple API for semantic search on documentation,
-//! designed to integrate with the existing indexing system.
+//! ドキュメントコメントのセマンティック検索機能を提供します。
+//! 既存のインデックスシステムと統合するシンプルなAPIを提供します。
+//!
+//! # 主要なコンポーネント
+//!
+//! - [`SimpleSemanticSearch`]: セマンティック検索の実装
+//! - [`SemanticVectorStorage`]: ベクトルストレージ
+//! - [`SemanticMetadata`]: セマンティック検索メタデータ
+//!
+//! # 使用例
+//!
+//! ```no_run
+//! use codanna::semantic::{SimpleSemanticSearch, EmbeddingModel};
+//! use std::path::Path;
+//!
+//! // let search = SimpleSemanticSearch::new(Path::new(".codanna"), EmbeddingModel::AllMiniLML6V2);
+//! // let results = search.search("find authentication functions", 10);
+//! ```
 
 mod metadata;
 mod simple;

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,3 +1,24 @@
+//! ストレージモジュール
+//!
+//! インデックスデータの永続化、検索エンジン (Tantivy)、メタデータ管理などを提供します。
+//!
+//! # 主要なコンポーネント
+//!
+//! - [`IndexPersistence`]: インデックスの永続化
+//! - [`DocumentIndex`]: Tantivy ベースの全文検索
+//! - [`IndexMetadata`]: インデックスメタデータ管理
+//! - [`MetadataKey`]: メタデータキーの定義
+//!
+//! # 使用例
+//!
+//! ```no_run
+//! use codanna::storage::{IndexPersistence, IndexMetadata};
+//! use std::path::Path;
+//!
+//! let path = Path::new(".codanna/index");
+//! let persistence = IndexPersistence::new(path);
+//! ```
+
 pub mod error;
 pub mod memory;
 pub mod metadata;

--- a/src/symbol/mod.rs
+++ b/src/symbol/mod.rs
@@ -1,3 +1,23 @@
+//! シンボル定義モジュール
+//!
+//! コード内のシンボル（関数、構造体、変数など）を表現する型を提供します。
+//!
+//! # 主要な型
+//!
+//! - [`Symbol`]: シンボルの完全な情報
+//! - [`CompactSymbol`]: メモリ効率の良いシンボル表現
+//! - [`Visibility`]: シンボルの可視性
+//! - [`ScopeContext`]: スコープ情報
+//!
+//! # 使用例
+//!
+//! ```
+//! use codanna::symbol::Visibility;
+//!
+//! let vis = Visibility::Public;
+//! assert_eq!(vis, Visibility::Public);
+//! ```
+
 pub mod context;
 
 use crate::parsing::registry::LanguageId;

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1,3 +1,24 @@
+//! 基本型定義モジュール
+//!
+//! このモジュールは、Codannaシステム全体で使用される基本的な型を定義します。
+//! シンボルID、ファイルID、範囲、シンボル種別などが含まれます。
+//!
+//! # 使用例
+//!
+//! ```
+//! use codanna::types::{SymbolId, FileId, Range, SymbolKind};
+//!
+//! // シンボルIDの作成
+//! let symbol_id = SymbolId::new(42).expect("有効なID");
+//!
+//! // ファイルIDの作成
+//! let file_id = FileId::new(1).expect("有効なID");
+//!
+//! // 範囲の作成
+//! let range = Range::new(10, 5, 15, 20);
+//! assert!(range.contains(12, 10));
+//! ```
+
 mod symbol_counter;
 
 pub use symbol_counter::SymbolCounter;
@@ -5,22 +26,75 @@ pub use symbol_counter::SymbolCounter;
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 
+/// シンボルの一意識別子
+///
+/// 各シンボル（関数、構造体、変数など）に割り当てられる一意のIDです。
+/// 0は無効な値として扱われます。
+///
+/// # 使用例
+///
+/// ```
+/// use codanna::types::SymbolId;
+///
+/// let id = SymbolId::new(42).expect("有効なID");
+/// assert_eq!(id.value(), 42);
+/// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct SymbolId(pub u32);
 
+/// ファイルの一意識別子
+///
+/// インデックス化された各ファイルに割り当てられる一意のIDです。
+/// 0は無効な値として扱われます。
+///
+/// # 使用例
+///
+/// ```
+/// use codanna::types::FileId;
+///
+/// let id = FileId::new(1).expect("有効なID");
+/// assert_eq!(id.value(), 1);
+/// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct FileId(pub u32);
 
-/// Result of an indexing operation
+/// インデックス操作の結果
+///
+/// ファイルが新規にインデックス化されたか、
+/// キャッシュから読み込まれたかを示します。
+///
+/// # 使用例
+///
+/// ```
+/// use codanna::types::{IndexingResult, FileId};
+///
+/// let result = IndexingResult::Indexed(FileId::new(1).unwrap());
+/// assert!(!result.is_cached());
+/// assert_eq!(result.file_id(), FileId::new(1).unwrap());
+/// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum IndexingResult {
-    /// File was newly indexed
+    /// ファイルが新規にインデックス化された
     Indexed(FileId),
-    /// File was loaded from cache (unchanged)
+    /// ファイルがキャッシュから読み込まれた（変更なし）
     Cached(FileId),
 }
 
 impl IndexingResult {
+    /// ファイルIDを取得します
+    ///
+    /// # 戻り値
+    ///
+    /// インデックス化されたファイルのID
+    ///
+    /// # 使用例
+    ///
+    /// ```
+    /// use codanna::types::{IndexingResult, FileId};
+    ///
+    /// let result = IndexingResult::Indexed(FileId::new(1).unwrap());
+    /// assert_eq!(result.file_id(), FileId::new(1).unwrap());
+    /// ```
     pub fn file_id(&self) -> FileId {
         match self {
             IndexingResult::Indexed(id) => *id,
@@ -28,34 +102,82 @@ impl IndexingResult {
         }
     }
 
+    /// キャッシュから読み込まれたかどうかを判定します
+    ///
+    /// # 戻り値
+    ///
+    /// キャッシュから読み込まれた場合は`true`、新規にインデックス化された場合は`false`
     pub fn is_cached(&self) -> bool {
         matches!(self, IndexingResult::Cached(_))
     }
 }
 
+/// ソースコード内の範囲
+///
+/// 行と列の位置で範囲を表現します。
+///
+/// # 使用例
+///
+/// ```
+/// use codanna::types::Range;
+///
+/// let range = Range::new(10, 5, 15, 20);
+/// assert!(range.contains(12, 10));
+/// assert!(!range.contains(5, 0));
+/// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Range {
+    /// 開始行
     pub start_line: u32,
+    /// 開始列
     pub start_column: u16,
+    /// 終了行
     pub end_line: u32,
+    /// 終了列
     pub end_column: u16,
 }
 
+/// シンボルの種類
+///
+/// 関数、構造体、クラスなど、様々な種類のシンボルを表現します。
+///
+/// # 使用例
+///
+/// ```
+/// use codanna::types::SymbolKind;
+///
+/// let kind = SymbolKind::Function;
+/// assert_eq!(kind, SymbolKind::Function);
+/// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum SymbolKind {
+    /// 関数
     Function,
+    /// メソッド
     Method,
+    /// 構造体
     Struct,
+    /// 列挙型
     Enum,
+    /// トレイト
     Trait,
+    /// インターフェース
     Interface,
+    /// クラス
     Class,
+    /// モジュール
     Module,
+    /// 変数
     Variable,
+    /// 定数
     Constant,
+    /// フィールド
     Field,
+    /// パラメータ
     Parameter,
+    /// 型エイリアス
     TypeAlias,
+    /// マクロ
     Macro,
 }
 

--- a/src/vector/mod.rs
+++ b/src/vector/mod.rs
@@ -1,18 +1,28 @@
-//! Vector search functionality for code intelligence.
+//! ベクトル検索モジュール
 //!
-//! This module provides high-performance vector storage and search capabilities
-//! designed to integrate with the existing Tantivy-based text search infrastructure.
+//! コードインテリジェンスのための高性能なベクトルストレージと検索機能を提供します。
+//! 既存のTantivyベースのテキスト検索インフラと統合するように設計されています。
 //!
-//! # Performance Targets
-//! - Vector access: <1μs per vector
-//! - Memory usage: ~100 bytes per symbol
-//! - Indexing: 10,000+ files/second
-//! - Search latency: <10ms for semantic search
+//! # パフォーマンス目標
 //!
-//! # Architecture
-//! The vector search system uses IVFFlat (Inverted File with Flat vectors) indexing
-//! with K-means clustering to achieve sub-linear search performance. Vectors are
-//! stored in memory-mapped files for instant loading and minimal memory overhead.
+//! - ベクトルアクセス: <1μs per vector
+//! - メモリ使用量: ~100 bytes per symbol
+//! - インデックス作成: 10,000+ files/second
+//! - 検索レイテンシ: <10ms for semantic search
+//!
+//! # アーキテクチャ
+//!
+//! ベクトル検索システムは、IVFFlat（Inverted File with Flat vectors）インデックスと
+//! K-meansクラスタリングを使用して、準線形の検索パフォーマンスを実現します。
+//! ベクトルはメモリマップドファイルに保存され、即座のロードと最小限のメモリオーバーヘッドを実現します。
+//!
+//! # 使用例
+//!
+//! ```no_run
+//! use codanna::vector::{VectorEngine, VectorStorage};
+//! // let engine = VectorEngine::new();
+//! // let results = engine.search(query_vector, top_k);
+//! ```
 
 mod clustering;
 mod embedding;


### PR DESCRIPTION
プロジェクト内のすべての主要なRustソースファイルに、rustdoc形式の
詳細な日本語コメントを追加しました。

変更内容:
- モジュールレベルのドキュメント追加
- 構造体、列挙型、関数への詳細なコメント
- 使用例の追加
- パラメータと戻り値の説明

対象ファイル:
- src/lib.rs: クレート全体の概要とマクロ
- src/error.rs: エラー型の詳細な説明
- src/config.rs: 設定構造体の説明
- src/types/mod.rs: 基本型定義
- src/init.rs: 初期化モジュール
- 各種モジュール (indexing, parsing, storage, vector, semantic等)

すべてのコメントはrustdoc形式に準拠し、日本語で記述されています。