### PR TITLE
Fix profile install for symlinked directories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -747,7 +747,7 @@ checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
 name = "codanna"
-version = "0.9.15"
+version = "0.9.14"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codanna"
-version = "0.9.15"
+version = "0.9.14"
 authors = ["Angel Bartolli <bartolli@gmail.com>"]
 edition = "2024"
 description = "Code Intelligence for Large Language Models"

--- a/src/profiles/installer.rs
+++ b/src/profiles/installer.rs
@@ -79,6 +79,10 @@ pub fn check_all_conflicts(
                     // Force enabled - will use sidecar
                 }
                 None => {
+                    if path_owned_by_profile(lockfile, profile_name, file_path) {
+                        // Directory path owned through tracked child files
+                        continue;
+                    }
                     // File exists but unknown owner (user's file or orphaned)
                     if !force {
                         conflicts.push((file_path.clone(), "unknown".to_string()));


### PR DESCRIPTION
## Description
Fixes issue #90 where profile installation fails when a profile contains a symlink to a directory.

It fixes the bug in two core ways:
  1. Directory symlink targets are now copied recursively instead of treated like a single file.
    - Previously, install used `std::fs::copy(...)` directly, which fails when source resolves to a directory.
    - Now it routes through `copy_source_entry(...)`, which detects directories and calls `copy_directory_contents(...)` with `WalkDir::new(...).follow_links(true)`.
  2. Lockfile/conflict logic now handles directory-owned paths correctly on reinstall.
    - Copied nested files are tracked in installed (so lockfile gets actual file paths under the symlinked dir).
    - Conflict handling treats a path as owned if any tracked child file is under that path (`path_owned_by_profile`), avoiding false sidecar creation during --force reinstall.

Fixes #90

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] Tests pass locally (`cargo test symlinked_directory`)
- [x] Added new tests
- [ ] Performance verified

## Performance impact
No material impact expected for normal installs.
The change applies to profile entries that resolve to directories.

## Breaking changes
None.

## Examples
- Added `test_install_profile_supports_symlinked_directory`
- Added `test_force_reinstall_symlinked_directory_overwrites_owned_files`

## Checklist
- [x] Code follows guidelines
- [x] Self-reviewed
- [x] Documentation updated (no user-facing doc changes required for this bug fix)
- [x] No new warnings
