### PR TITLE
feat(parsing): add Svelte parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -841,6 +841,7 @@ dependencies = [
  "tree-sitter-php",
  "tree-sitter-python",
  "tree-sitter-rust",
+ "tree-sitter-svelte-next",
  "tree-sitter-swift",
  "tree-sitter-typescript",
  "walkdir",
@@ -5408,6 +5409,16 @@ name = "tree-sitter-rust"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439e577dbe07423ec2582ac62c7531120dbfccfa6e5f92406f93dd271a120e45"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-svelte-next"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f88190d0743e897c3e148a7e241aba0a8844b8afe816943851426e3f7b9753"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,6 +105,7 @@ async-trait = "0.1.89"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 sysinfo = "0.39.2"
 indexmap = { version = "2.14.0", features = ["serde"] }
+tree-sitter-svelte-next = "0.1.1"
 
 [dev-dependencies]
 criterion = { version = "0.8.2", features = ["html_reports"] }

--- a/contributing/parsers/svelte/AUDIT_REPORT.md
+++ b/contributing/parsers/svelte/AUDIT_REPORT.md
@@ -1,0 +1,66 @@
+# Svelte Parser Symbol Extraction Coverage Report
+
+*Generated: 2026-05-22 19:33:09 UTC*
+
+## Summary
+- Key nodes: 5/20 (25%)
+- Symbol kinds extracted: 4
+
+> **Note:** Svelte delegates `<script>` bodies to the JS/TS parsers; the nodes below are the Svelte-level constructs handled directly.
+
+## Coverage Table
+
+| Node Type | ID | Status |
+|-----------|-----|--------|
+| document | 52 | ⚠️ gap |
+| script_element | 56 | ✅ implemented |
+| style_element | - | ❌ not found |
+| start_tag | 58 | ⚠️ gap |
+| end_tag | 62 | ⚠️ gap |
+| raw_text | 47 | ✅ implemented |
+| attribute | 64 | ⚠️ gap |
+| attribute_name | 9 | ⚠️ gap |
+| quoted_attribute_value | 65 | ⚠️ gap |
+| element | 55 | ⚠️ gap |
+| expression_tag | 107 | ⚠️ gap |
+| render_tag | 114 | ⚠️ gap |
+| snippet_statement | 100 | ✅ implemented |
+| snippet_start | 102 | ✅ implemented |
+| snippet_name | 32 | ✅ implemented |
+| if_statement | 68 | ⚠️ gap |
+| each_statement | 79 | ⚠️ gap |
+| await_statement | - | ❌ not found |
+| key_statement | - | ❌ not found |
+| comment | 48 | ⚠️ gap |
+
+## Legend
+
+- ✅ **implemented**: Node type is recognized and handled by the parser
+- ⚠️ **gap**: Node type exists in the grammar but not handled by parser (needs implementation)
+- ❌ **not found**: Node type not present in the example file (may need better examples)
+
+## Recommended Actions
+
+### Priority 1: Implementation Gaps
+These nodes exist in your code but aren't being captured:
+
+- `document`: Add parsing logic in parser.rs
+- `start_tag`: Add parsing logic in parser.rs
+- `end_tag`: Add parsing logic in parser.rs
+- `attribute`: Add parsing logic in parser.rs
+- `attribute_name`: Add parsing logic in parser.rs
+- `quoted_attribute_value`: Add parsing logic in parser.rs
+- `element`: Add parsing logic in parser.rs
+- `expression_tag`: Add parsing logic in parser.rs
+- `render_tag`: Add parsing logic in parser.rs
+- `if_statement`: Add parsing logic in parser.rs
+- `each_statement`: Add parsing logic in parser.rs
+- `comment`: Add parsing logic in parser.rs
+
+### Priority 2: Missing Examples
+These nodes aren't in the comprehensive example. Consider:
+
+- `style_element`: Add example to comprehensive.svelte or verify node name
+- `await_statement`: Add example to comprehensive.svelte or verify node name
+- `key_statement`: Add example to comprehensive.svelte or verify node name
+

--- a/contributing/parsers/svelte/GRAMMAR_ANALYSIS.md
+++ b/contributing/parsers/svelte/GRAMMAR_ANALYSIS.md
@@ -1,0 +1,99 @@
+# Svelte Grammar Analysis
+
+*Generated: 2026-05-22 19:33:09 UTC*
+
+## Statistics
+- Total nodes in grammar JSON: 54
+- Nodes found in comprehensive.svelte: 53
+- Nodes handled by parser: 5
+- Symbol kinds extracted: 4
+
+## Successfully Handled Nodes
+These nodes are in examples and handled by parser:
+- raw_text
+- script_element
+- snippet_name
+- snippet_start
+- snippet_statement
+
+## Implementation Gaps
+These nodes appear in comprehensive.svelte but aren't handled:
+- "
+- #
+- (
+- )
+- /
+- />
+- :
+- <
+- </
+- =
+- >
+- @
+- as
+- attribute
+- attribute_name
+- attribute_value
+- block_end_tag
+- block_start_tag
+- block_tag
+- comment
+- document
+- each
+- each_end
+- each_start
+- each_statement
+- element
+- else
+- else_block
+- else_start
+- end_tag
+- expression
+- expression_tag
+- if
+- if_end
+- if_start
+- if_statement
+- quoted_attribute_value
+- render
+- render_tag
+- self_closing_tag
+- snippet
+- snippet_end
+- start_tag
+- svelte_raw_text
+- tag_name
+- text
+- {
+- }
+
+## Missing from Examples
+These grammar nodes aren't in comprehensive.svelte:
+- _node
+- await_end
+- await_start
+- await_statement
+- catch_block
+- catch_start
+- const_tag
+- debug_tag
+- doctype
+- else_if_block
+- else_if_start
+- entity
+- erroneous_end_tag
+- erroneous_end_tag_name
+- html_tag
+- key_end
+- key_start
+- key_statement
+- style_element
+- then_block
+- then_start
+
+## Symbol Kinds Extracted
+- Constant
+- Function
+- Interface
+- Variable
+

--- a/contributing/parsers/svelte/node-types.json
+++ b/contributing/parsers/svelte/node-types.json
@@ -1,0 +1,1164 @@
+[
+  {
+    "type": "_node",
+    "named": true,
+    "subtypes": [
+      {
+        "type": "await_statement",
+        "named": true
+      },
+      {
+        "type": "const_tag",
+        "named": true
+      },
+      {
+        "type": "debug_tag",
+        "named": true
+      },
+      {
+        "type": "doctype",
+        "named": true
+      },
+      {
+        "type": "each_statement",
+        "named": true
+      },
+      {
+        "type": "element",
+        "named": true
+      },
+      {
+        "type": "entity",
+        "named": true
+      },
+      {
+        "type": "erroneous_end_tag",
+        "named": true
+      },
+      {
+        "type": "expression",
+        "named": true
+      },
+      {
+        "type": "html_tag",
+        "named": true
+      },
+      {
+        "type": "if_statement",
+        "named": true
+      },
+      {
+        "type": "key_statement",
+        "named": true
+      },
+      {
+        "type": "render_tag",
+        "named": true
+      },
+      {
+        "type": "script_element",
+        "named": true
+      },
+      {
+        "type": "snippet_statement",
+        "named": true
+      },
+      {
+        "type": "style_element",
+        "named": true
+      },
+      {
+        "type": "text",
+        "named": true
+      }
+    ]
+  },
+  {
+    "type": "attribute",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "attribute_name",
+          "named": true
+        },
+        {
+          "type": "attribute_value",
+          "named": true
+        },
+        {
+          "type": "expression",
+          "named": true
+        },
+        {
+          "type": "quoted_attribute_value",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "attribute_name",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "svelte_raw_text",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "attribute_value",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "await_end",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "block_end_tag",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "await_start",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "block_start_tag",
+          "named": true
+        },
+        {
+          "type": "svelte_raw_text",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "await_statement",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "_node",
+          "named": true
+        },
+        {
+          "type": "await_end",
+          "named": true
+        },
+        {
+          "type": "await_start",
+          "named": true
+        },
+        {
+          "type": "catch_block",
+          "named": true
+        },
+        {
+          "type": "then_block",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "block_end_tag",
+    "named": true,
+    "fields": {
+      "tag": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "await",
+            "named": false
+          },
+          {
+            "type": "each",
+            "named": false
+          },
+          {
+            "type": "if",
+            "named": false
+          },
+          {
+            "type": "key",
+            "named": false
+          },
+          {
+            "type": "snippet",
+            "named": false
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "block_start_tag",
+    "named": true,
+    "fields": {
+      "tag": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "await",
+            "named": false
+          },
+          {
+            "type": "each",
+            "named": false
+          },
+          {
+            "type": "if",
+            "named": false
+          },
+          {
+            "type": "key",
+            "named": false
+          },
+          {
+            "type": "snippet",
+            "named": false
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "block_tag",
+    "named": true,
+    "fields": {
+      "tag": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "catch",
+            "named": false
+          },
+          {
+            "type": "else",
+            "named": false
+          },
+          {
+            "type": "else if",
+            "named": false
+          },
+          {
+            "type": "then",
+            "named": false
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "catch_block",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "_node",
+          "named": true
+        },
+        {
+          "type": "catch_start",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "catch_start",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "block_tag",
+          "named": true
+        },
+        {
+          "type": "svelte_raw_text",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "const_tag",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "expression_tag",
+          "named": true
+        },
+        {
+          "type": "svelte_raw_text",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "debug_tag",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "expression_tag",
+          "named": true
+        },
+        {
+          "type": "svelte_raw_text",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "doctype",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "document",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "_node",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "each_end",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "block_end_tag",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "each_start",
+    "named": true,
+    "fields": {
+      "identifier": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "svelte_raw_text",
+            "named": true
+          }
+        ]
+      },
+      "parameter": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "svelte_raw_text",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "block_start_tag",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "each_statement",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "_node",
+          "named": true
+        },
+        {
+          "type": "each_end",
+          "named": true
+        },
+        {
+          "type": "each_start",
+          "named": true
+        },
+        {
+          "type": "else_block",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "element",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "_node",
+          "named": true
+        },
+        {
+          "type": "end_tag",
+          "named": true
+        },
+        {
+          "type": "self_closing_tag",
+          "named": true
+        },
+        {
+          "type": "start_tag",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "else_block",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "_node",
+          "named": true
+        },
+        {
+          "type": "else_start",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "else_if_block",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "_node",
+          "named": true
+        },
+        {
+          "type": "else_if_start",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "else_if_start",
+    "named": true,
+    "fields": {
+      "condition": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "svelte_raw_text",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "block_tag",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "else_start",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "block_tag",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "end_tag",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "tag_name",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "erroneous_end_tag",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "erroneous_end_tag_name",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "expression",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "svelte_raw_text",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "expression_tag",
+    "named": true,
+    "fields": {
+      "tag": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "const",
+            "named": false
+          },
+          {
+            "type": "debug",
+            "named": false
+          },
+          {
+            "type": "html",
+            "named": false
+          },
+          {
+            "type": "render",
+            "named": false
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "html_tag",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "expression_tag",
+          "named": true
+        },
+        {
+          "type": "svelte_raw_text",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "if_end",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "block_end_tag",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "if_start",
+    "named": true,
+    "fields": {
+      "condition": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "svelte_raw_text",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "block_start_tag",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "if_statement",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "_node",
+          "named": true
+        },
+        {
+          "type": "else_block",
+          "named": true
+        },
+        {
+          "type": "else_if_block",
+          "named": true
+        },
+        {
+          "type": "if_end",
+          "named": true
+        },
+        {
+          "type": "if_start",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "key_end",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "block_end_tag",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "key_start",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "block_start_tag",
+          "named": true
+        },
+        {
+          "type": "svelte_raw_text",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "key_statement",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "_node",
+          "named": true
+        },
+        {
+          "type": "key_end",
+          "named": true
+        },
+        {
+          "type": "key_start",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "quoted_attribute_value",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "attribute_value",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "render_tag",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "expression_tag",
+          "named": true
+        },
+        {
+          "type": "svelte_raw_text",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "script_element",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "end_tag",
+          "named": true
+        },
+        {
+          "type": "raw_text",
+          "named": true
+        },
+        {
+          "type": "start_tag",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "self_closing_tag",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "attribute",
+          "named": true
+        },
+        {
+          "type": "tag_name",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "snippet_end",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "block_end_tag",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "snippet_start",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "block_start_tag",
+          "named": true
+        },
+        {
+          "type": "snippet_name",
+          "named": true
+        },
+        {
+          "type": "svelte_raw_text",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "snippet_statement",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "_node",
+          "named": true
+        },
+        {
+          "type": "snippet_end",
+          "named": true
+        },
+        {
+          "type": "snippet_start",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "start_tag",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "attribute",
+          "named": true
+        },
+        {
+          "type": "tag_name",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "style_element",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "end_tag",
+          "named": true
+        },
+        {
+          "type": "raw_text",
+          "named": true
+        },
+        {
+          "type": "start_tag",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "then_block",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "_node",
+          "named": true
+        },
+        {
+          "type": "then_start",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "then_start",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "block_tag",
+          "named": true
+        },
+        {
+          "type": "svelte_raw_text",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "\"",
+    "named": false
+  },
+  {
+    "type": "#",
+    "named": false
+  },
+  {
+    "type": "'",
+    "named": false
+  },
+  {
+    "type": "(",
+    "named": false
+  },
+  {
+    "type": ")",
+    "named": false
+  },
+  {
+    "type": "/",
+    "named": false
+  },
+  {
+    "type": "/>",
+    "named": false
+  },
+  {
+    "type": ":",
+    "named": false
+  },
+  {
+    "type": "<",
+    "named": false
+  },
+  {
+    "type": "<!",
+    "named": false
+  },
+  {
+    "type": "</",
+    "named": false
+  },
+  {
+    "type": "=",
+    "named": false
+  },
+  {
+    "type": ">",
+    "named": false
+  },
+  {
+    "type": "@",
+    "named": false
+  },
+  {
+    "type": "as",
+    "named": false
+  },
+  {
+    "type": "await",
+    "named": false
+  },
+  {
+    "type": "catch",
+    "named": false
+  },
+  {
+    "type": "comment",
+    "named": true
+  },
+  {
+    "type": "const",
+    "named": false
+  },
+  {
+    "type": "debug",
+    "named": false
+  },
+  {
+    "type": "doctype",
+    "named": false
+  },
+  {
+    "type": "each",
+    "named": false
+  },
+  {
+    "type": "else",
+    "named": false
+  },
+  {
+    "type": "else if",
+    "named": false
+  },
+  {
+    "type": "entity",
+    "named": true
+  },
+  {
+    "type": "erroneous_end_tag_name",
+    "named": true
+  },
+  {
+    "type": "html",
+    "named": false
+  },
+  {
+    "type": "if",
+    "named": false
+  },
+  {
+    "type": "key",
+    "named": false
+  },
+  {
+    "type": "raw_text",
+    "named": true
+  },
+  {
+    "type": "render",
+    "named": false
+  },
+  {
+    "type": "snippet",
+    "named": false
+  },
+  {
+    "type": "snippet_name",
+    "named": true
+  },
+  {
+    "type": "svelte_raw_text",
+    "named": true
+  },
+  {
+    "type": "tag_name",
+    "named": true
+  },
+  {
+    "type": "text",
+    "named": true
+  },
+  {
+    "type": "then",
+    "named": false
+  },
+  {
+    "type": "{",
+    "named": false
+  },
+  {
+    "type": "}",
+    "named": false
+  }
+]

--- a/contributing/parsers/svelte/node_discovery.txt
+++ b/contributing/parsers/svelte/node_discovery.txt
@@ -1,0 +1,82 @@
+=== Svelte Language NODE MAPPING ===
+  Generated: 2026-05-22 19:33:09 UTC
+  ABI Version: 14
+  Node kind count: 53
+
+=== SCRIPT NODES ===
+  + script_element                      -> ID: 56
+  x style_element                       NOT FOUND
+  + start_tag                           -> ID: 58
+  + end_tag                             -> ID: 62
+  + raw_text                            -> ID: 47
+
+=== ATTRIBUTE NODES ===
+  + attribute                           -> ID: 64
+  + attribute_name                      -> ID: 9
+  + attribute_value                     -> ID: 10
+  + quoted_attribute_value              -> ID: 65
+
+=== ELEMENT NODES ===
+  + element                             -> ID: 55
+  + self_closing_tag                    -> ID: 61
+  + tag_name                            -> ID: 41
+  + text                                -> ID: 14
+  x doctype                             NOT FOUND
+
+=== EXPRESSION NODES ===
+  + expression                          -> ID: 105
+  + expression_tag                      -> ID: 107
+  + render_tag                          -> ID: 114
+  x html_tag                            NOT FOUND
+  x const_tag                           NOT FOUND
+  x debug_tag                           NOT FOUND
+  + svelte_raw_text                     -> ID: 49
+
+=== BLOCK NODES ===
+  + if_statement                        -> ID: 68
+  + each_statement                      -> ID: 79
+  x await_statement                     NOT FOUND
+  x key_statement                       NOT FOUND
+  + block_start_tag                     -> ID: 69
+  + block_end_tag                       -> ID: 77
+  + else_block                          -> ID: 76
+
+=== SNIPPET NODES ===
+  + snippet_statement                   -> ID: 100
+  + snippet_start                       -> ID: 102
+  + snippet_name                        -> ID: 32
+  + snippet_end                         -> ID: 104
+
+=== COMMENT NODES ===
+  + comment                             -> ID: 48
+
+=== UNCATEGORIZED NODES ===
+  + "                                   -> ID: 13
+  + #                                   -> ID: 17
+  + (                                   -> ID: 33
+  + )                                   -> ID: 34
+  + /                                   -> ID: 24
+  + />                                  -> ID: 6
+  + :                                   -> ID: 21
+  + <                                   -> ID: 5
+  + </                                  -> ID: 7
+  + =                                   -> ID: 8
+  + >                                   -> ID: 3
+  + @                                   -> ID: 36
+  + as                                  -> ID: 26
+  + block_tag                           -> ID: 71
+  + document                            -> ID: 52
+  + each                                -> ID: 25
+  + each_end                            -> ID: 83
+  + each_start                          -> ID: 81
+  + else                                -> ID: 23
+  + else_start                          -> ID: 75
+  + if                                  -> ID: 18
+  + if_end                              -> ID: 78
+  + if_start                            -> ID: 70
+  + render                              -> ID: 40
+  + snippet                             -> ID: 31
+  + {                                   -> ID: 19
+  + }                                   -> ID: 20
+
+Legend: + = found in file, o = in grammar but not in file, x = not in grammar

--- a/contributing/tree-sitter/scripts/setup.sh
+++ b/contributing/tree-sitter/scripts/setup.sh
@@ -38,10 +38,11 @@ if [ -n "$LANG" ]; then
         java) REPO="https://github.com/tree-sitter/tree-sitter-java" ;;
         clojure) REPO="https://codeberg.org/grammar-orchard/tree-sitter-clojure-orchard" ;;
         lua) REPO="https://github.com/tree-sitter-grammars/tree-sitter-lua" ;;
+        svelte) REPO="https://github.com/PRRPCHT/tree-sitter-svelte-next" ;;
         swift) REPO="https://github.com/alex-pinkus/tree-sitter-swift" ;;
         *)
             echo "❌ Unknown language: $LANG"
-            echo "Supported: typescript, javascript, python, rust, go, php, c, clojure, cpp, csharp, gdscript, kotlin, java, lua, swift"
+            echo "Supported: typescript, javascript, python, rust, go, php, c, clojure, cpp, csharp, gdscript, kotlin, java, lua, svelte, swift"
             exit 1
             ;;
     esac

--- a/examples/svelte/comprehensive.svelte
+++ b/examples/svelte/comprehensive.svelte
@@ -1,0 +1,95 @@
+<!--
+  Comprehensive Svelte 5 component for parser maturity assessment.
+
+  Exercises both code paths and the template constructs the parser handles:
+  - a module `<script module>` block (plain JS) -> JavaScript sub-parser
+  - an instance `<script lang="ts">` block      -> TypeScript sub-parser
+  - imports (value, default, and type-only)
+  - functions, $state / $derived / $effect runes
+  - {#snippet} definitions and {@render} usage
+  - {#if} and {#each} template blocks
+-->
+
+<script module>
+    // Module context: runs once per module (plain JavaScript on purpose, so the
+    // JS sub-parser path is covered alongside the TS instance block below).
+    import { formatDate } from './utils/date.js';
+
+    export const COMPONENT_VERSION = '1.0.0';
+
+    let instanceCount = 0;
+
+    /** Track how many instances have been created. */
+    export function nextInstanceId() {
+        instanceCount += 1;
+        return instanceCount;
+    }
+
+    export { formatDate };
+</script>
+
+<script lang="ts">
+    // Instance context: TypeScript (the Svelte 5 default).
+    import Counter from './Counter.svelte';
+    import { fetchUsers } from './api/users.ts';
+    import type { User } from './types/user.ts';
+
+    interface PanelProps {
+        title: string;
+        max?: number;
+    }
+
+    let { title, max = 100 }: PanelProps = $props();
+
+    // Runes: reactive state and derived values.
+    let count = $state(0);
+    let users = $state<User[]>([]);
+    let doubled = $derived(count * 2);
+    let isMaxed = $derived(count >= max);
+
+    $effect(() => {
+        console.log(`count changed to ${count}`);
+    });
+
+    function increment(): void {
+        count += 1;
+    }
+
+    function reset(): void {
+        count = 0;
+    }
+
+    async function loadUsers(): Promise<void> {
+        users = await fetchUsers();
+    }
+
+    const greeting = (user: User): string => `Hello, ${user.name}`;
+</script>
+
+<section>
+    <h1>{title} (v{COMPONENT_VERSION})</h1>
+
+    <!-- snippet definition: emitted as a Function symbol -->
+    {#snippet userRow(user: User)}
+        <li>{greeting(user)}</li>
+    {/snippet}
+
+    <Counter {count} on:increment={increment} />
+
+    <p>Doubled: {doubled}</p>
+
+    {#if isMaxed}
+        <strong>Maxed out!</strong>
+    {:else}
+        <button onclick={increment}>Increment</button>
+        <button onclick={reset}>Reset</button>
+    {/if}
+
+    <ul>
+        {#each users as user (user.id)}
+            {@render userRow(user)}
+        {/each}
+    </ul>
+
+    <button onclick={loadUsers}>Load users</button>
+</section>

--- a/flake.lock
+++ b/flake.lock
@@ -109,11 +109,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1774062094,
-        "narHash": "sha256-ba3c+hS7KzEiwtZRGHagIAYdcmdY3rCSWVCyn64rx7s=",
+        "lastModified": 1779333539,
+        "narHash": "sha256-lpmN2lrBDZDPjov2cbD3bOOJsI0fkKolKXasYPCqSys=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "c807e83cc2e32adc35f51138b3bdef722c0812ab",
+        "rev": "672fa5fc5608d5cd82286a6f69aaf84a40b4fe41",
         "type": "github"
       },
       "original": {

--- a/src/io/parse.rs
+++ b/src/io/parse.rs
@@ -265,6 +265,7 @@ pub fn execute_parse(
         Language::Kotlin => tree_sitter_kotlin::language(),
         Language::Lua => tree_sitter_lua::LANGUAGE.into(),
         Language::Swift => tree_sitter_swift::LANGUAGE.into(),
+        Language::Svelte => tree_sitter_svelte_next::LANGUAGE.into(),
     };
 
     parser

--- a/src/parsing/factory.rs
+++ b/src/parsing/factory.rs
@@ -190,6 +190,10 @@ impl ParserFactory {
                 let parser = SwiftParser::new().map_err(|e| IndexError::General(e.to_string()))?;
                 Ok(Box::new(parser))
             }
+            Language::Svelte => {
+                let parser = SvelteParser::new().map_err(|e| IndexError::General(e.to_string()))?;
+                Ok(Box::new(parser))
+            }
         }
     }
 

--- a/src/parsing/factory.rs
+++ b/src/parsing/factory.rs
@@ -337,8 +337,7 @@ impl ParserFactory {
                 }
             }
             Language::Svelte => {
-                let parser =
-                    SvelteParser::new().map_err(|e| IndexError::General(e.to_string()))?;
+                let parser = SvelteParser::new().map_err(|e| IndexError::General(e.to_string()))?;
                 ParserWithBehavior {
                     parser: Box::new(parser),
                     behavior: Box::new(SvelteBehavior::new()),

--- a/src/parsing/factory.rs
+++ b/src/parsing/factory.rs
@@ -8,8 +8,8 @@ use super::{
     CppParser, GdscriptBehavior, GdscriptParser, GoBehavior, GoParser, JavaBehavior, JavaParser,
     JavaScriptBehavior, JavaScriptParser, KotlinBehavior, KotlinParser, Language, LanguageBehavior,
     LanguageId, LanguageParser, LuaBehavior, LuaParser, PhpBehavior, PhpParser, PythonBehavior,
-    PythonParser, RustBehavior, RustParser, SwiftBehavior, SwiftParser, TypeScriptBehavior,
-    TypeScriptParser, get_registry,
+    PythonParser, RustBehavior, RustParser, SvelteBehavior, SvelteParser, SwiftBehavior,
+    SwiftParser, TypeScriptBehavior, TypeScriptParser, get_registry,
 };
 use crate::{IndexError, IndexResult, Settings};
 use std::sync::Arc;
@@ -336,6 +336,14 @@ impl ParserFactory {
                     behavior: Box::new(SwiftBehavior::new()),
                 }
             }
+            Language::Svelte => {
+                let parser =
+                    SvelteParser::new().map_err(|e| IndexError::General(e.to_string()))?;
+                ParserWithBehavior {
+                    parser: Box::new(parser),
+                    behavior: Box::new(SvelteBehavior::new()),
+                }
+            }
         };
 
         Ok(result)
@@ -376,6 +384,7 @@ impl ParserFactory {
             Language::Php,
             Language::Python,
             Language::Rust,
+            Language::Svelte,
             Language::Swift,
             Language::TypeScript,
         ]

--- a/src/parsing/language.rs
+++ b/src/parsing/language.rs
@@ -23,6 +23,7 @@ pub enum Language {
     Kotlin,
     Lua,
     Swift,
+    Svelte,
 }
 
 impl Language {
@@ -48,6 +49,7 @@ impl Language {
             Language::Kotlin => super::LanguageId::new("kotlin"),
             Language::Lua => super::LanguageId::new("lua"),
             Language::Swift => super::LanguageId::new("swift"),
+            Language::Svelte => super::LanguageId::new("svelte"),
         }
     }
 
@@ -72,6 +74,7 @@ impl Language {
             "kotlin" => Some(Language::Kotlin),
             "lua" => Some(Language::Lua),
             "swift" => Some(Language::Swift),
+            "svelte" => Some(Language::Svelte),
             _ => None,
         }
     }
@@ -111,6 +114,7 @@ impl Language {
             "kt" | "kts" => Some(Language::Kotlin),
             "lua" => Some(Language::Lua),
             "swift" => Some(Language::Swift),
+            "svelte" => Some(Language::Svelte),
             _ => None,
         }
     }
@@ -142,6 +146,7 @@ impl Language {
             Language::Kotlin => &["kt", "kts"],
             Language::Lua => &["lua"],
             Language::Swift => &["swift"],
+            Language::Svelte => &["svelte"],
         }
     }
 
@@ -163,6 +168,7 @@ impl Language {
             Language::Kotlin => "kotlin",
             Language::Lua => "lua",
             Language::Swift => "swift",
+            Language::Svelte => "svelte",
         }
     }
 
@@ -184,6 +190,7 @@ impl Language {
             Language::Kotlin => "Kotlin",
             Language::Lua => "Lua",
             Language::Swift => "Swift",
+            Language::Svelte => "Svelte",
         }
     }
 }

--- a/src/parsing/mod.rs
+++ b/src/parsing/mod.rs
@@ -22,6 +22,7 @@ pub mod python;
 pub mod registry;
 pub mod resolution;
 pub mod rust;
+pub mod svelte;
 pub mod swift;
 pub mod typescript;
 
@@ -58,5 +59,6 @@ pub use resolution::{
     PipelineSymbolCache, ResolutionScope, ResolveResult, ScopeLevel,
 };
 pub use rust::{RustBehavior, RustParser};
+pub use svelte::{SvelteBehavior, SvelteParser};
 pub use swift::{SwiftBehavior, SwiftParser};
 pub use typescript::{TypeScriptBehavior, TypeScriptParser};

--- a/src/parsing/registry.rs
+++ b/src/parsing/registry.rs
@@ -392,6 +392,7 @@ fn initialize_registry(registry: &mut LanguageRegistry) {
     super::clojure::register(registry);
     super::lua::register(registry);
     super::swift::register(registry);
+    super::svelte::register(registry);
 }
 
 /// Get the global registry

--- a/src/parsing/svelte/audit.rs
+++ b/src/parsing/svelte/audit.rs
@@ -1,0 +1,250 @@
+//! Svelte parser audit module
+//!
+//! Tracks which AST nodes the parser handles vs what's available in the grammar.
+//!
+//! Svelte symbol extraction is split: `<script>` bodies are delegated to the
+//! JS/TS parsers, while template constructs such as `{#snippet}` are handled
+//! directly against the tree-sitter-svelte grammar. This audit records the
+//! Svelte-level nodes the parser acts on (script blocks, raw text, snippets).
+
+use super::SvelteParser;
+use crate::io::format::format_utc_timestamp;
+use crate::parsing::{LanguageParser, NodeTracker};
+use crate::types::FileId;
+use std::collections::{HashMap, HashSet};
+use thiserror::Error;
+use tree_sitter::{Node, Parser};
+
+#[derive(Error, Debug)]
+pub enum AuditError {
+    #[error("Failed to read file: {0}")]
+    FileRead(#[from] std::io::Error),
+
+    #[error("Failed to set language: {0}")]
+    LanguageSetup(String),
+
+    #[error("Failed to parse code")]
+    ParseFailure,
+
+    #[error("Failed to create parser: {0}")]
+    ParserCreation(String),
+}
+
+pub struct SvelteParserAudit {
+    pub grammar_nodes: HashMap<String, u16>,
+    pub implemented_nodes: HashSet<String>,
+    pub extracted_symbol_kinds: HashSet<String>,
+}
+
+impl SvelteParserAudit {
+    pub fn audit_file(file_path: &str) -> Result<Self, AuditError> {
+        let code = std::fs::read_to_string(file_path)?;
+        Self::audit_code(&code)
+    }
+
+    pub fn audit_code(code: &str) -> Result<Self, AuditError> {
+        let mut parser = Parser::new();
+        let language = tree_sitter_svelte_next::LANGUAGE.into();
+        parser
+            .set_language(&language)
+            .map_err(|e| AuditError::LanguageSetup(e.to_string()))?;
+
+        let tree = parser.parse(code, None).ok_or(AuditError::ParseFailure)?;
+
+        let mut grammar_nodes = HashMap::new();
+        discover_nodes(tree.root_node(), &mut grammar_nodes);
+
+        let mut svelte_parser =
+            SvelteParser::new().map_err(|e| AuditError::ParserCreation(e.to_string()))?;
+        let file_id = FileId(1);
+        let mut symbol_counter = crate::types::SymbolCounter::new();
+        let symbols = svelte_parser.parse(code, file_id, &mut symbol_counter);
+
+        let mut extracted_symbol_kinds = HashSet::new();
+        for symbol in &symbols {
+            extracted_symbol_kinds.insert(format!("{:?}", symbol.kind));
+        }
+
+        let implemented_nodes: HashSet<String> = svelte_parser
+            .get_handled_nodes()
+            .iter()
+            .map(|handled_node| handled_node.name.clone())
+            .collect();
+
+        Ok(Self {
+            grammar_nodes,
+            implemented_nodes,
+            extracted_symbol_kinds,
+        })
+    }
+
+    pub fn generate_report(&self) -> String {
+        let mut report = String::new();
+
+        report.push_str("# Svelte Parser Symbol Extraction Coverage Report\n\n");
+        report.push_str(&format!("*Generated: {}*\n\n", format_utc_timestamp()));
+
+        let key_nodes = vec![
+            "document",
+            "script_element",
+            "style_element",
+            "start_tag",
+            "end_tag",
+            "raw_text",
+            "attribute",
+            "attribute_name",
+            "quoted_attribute_value",
+            "element",
+            "expression_tag",
+            "render_tag",
+            "snippet_statement",
+            "snippet_start",
+            "snippet_name",
+            "if_statement",
+            "each_statement",
+            "await_statement",
+            "key_statement",
+            "comment",
+        ];
+
+        let key_implemented = key_nodes
+            .iter()
+            .filter(|n| self.implemented_nodes.contains(**n))
+            .count();
+
+        report.push_str("## Summary\n");
+        report.push_str(&format!(
+            "- Key nodes: {}/{} ({}%)\n",
+            key_implemented,
+            key_nodes.len(),
+            (key_implemented * 100) / key_nodes.len()
+        ));
+        report.push_str(&format!(
+            "- Symbol kinds extracted: {}\n",
+            self.extracted_symbol_kinds.len()
+        ));
+        report.push_str(
+            "\n> **Note:** Svelte delegates `<script>` bodies to the JS/TS parsers; \
+             the nodes below are the Svelte-level constructs handled directly.\n\n",
+        );
+
+        report.push_str("## Coverage Table\n\n");
+        report.push_str("| Node Type | ID | Status |\n");
+        report.push_str("|-----------|-----|--------|\n");
+
+        let mut gaps = Vec::new();
+        let mut missing = Vec::new();
+
+        for node_name in &key_nodes {
+            let status = if let Some(id) = self.grammar_nodes.get(*node_name) {
+                if self.implemented_nodes.contains(*node_name) {
+                    format!("{id} | ✅ implemented")
+                } else {
+                    gaps.push(node_name);
+                    format!("{id} | ⚠️ gap")
+                }
+            } else {
+                missing.push(node_name);
+                "- | ❌ not found".to_string()
+            };
+            report.push_str(&format!("| {node_name} | {status} |\n"));
+        }
+
+        report.push_str("\n## Legend\n\n");
+        report
+            .push_str("- ✅ **implemented**: Node type is recognized and handled by the parser\n");
+        report.push_str("- ⚠️ **gap**: Node type exists in the grammar but not handled by parser (needs implementation)\n");
+        report.push_str("- ❌ **not found**: Node type not present in the example file (may need better examples)\n");
+
+        report.push_str("\n## Recommended Actions\n\n");
+
+        if !gaps.is_empty() {
+            report.push_str("### Priority 1: Implementation Gaps\n");
+            report.push_str("These nodes exist in your code but aren't being captured:\n\n");
+            for gap in &gaps {
+                report.push_str(&format!("- `{gap}`: Add parsing logic in parser.rs\n"));
+            }
+            report.push('\n');
+        }
+
+        if !missing.is_empty() {
+            report.push_str("### Priority 2: Missing Examples\n");
+            report.push_str("These nodes aren't in the comprehensive example. Consider:\n\n");
+            for node in &missing {
+                report.push_str(&format!(
+                    "- `{node}`: Add example to comprehensive.svelte or verify node name\n"
+                ));
+            }
+            report.push('\n');
+        }
+
+        if gaps.is_empty() && missing.is_empty() {
+            report.push_str("✨ **Excellent coverage!** All key nodes are implemented.\n");
+        }
+
+        report
+    }
+}
+
+fn discover_nodes(node: Node, registry: &mut HashMap<String, u16>) {
+    // Use iterative traversal with an explicit stack to avoid stack overflow on large ASTs
+    let mut stack = vec![node];
+
+    while let Some(current_node) = stack.pop() {
+        registry.insert(current_node.kind().to_string(), current_node.kind_id());
+
+        let mut cursor = current_node.walk();
+        // Push children onto the stack for processing
+        for child in current_node.children(&mut cursor) {
+            stack.push(child);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_audit_simple_svelte() {
+        let code = r#"<script lang="ts">
+    export function greet(name: string): string {
+        return `Hello ${name}`;
+    }
+</script>
+
+{#snippet card(item)}
+    <div>{item}</div>
+{/snippet}
+"#;
+
+        let audit = SvelteParserAudit::audit_code(code).unwrap();
+
+        assert!(audit.grammar_nodes.contains_key("script_element"));
+        assert!(audit.grammar_nodes.contains_key("snippet_statement"));
+
+        // Script body delegates to TS: greet is a Function.
+        assert!(audit.extracted_symbol_kinds.contains("Function"));
+
+        // Svelte-level nodes the parser acts on are registered.
+        assert!(audit.implemented_nodes.contains("script_element"));
+        assert!(audit.implemented_nodes.contains("snippet_statement"));
+    }
+
+    #[test]
+    fn test_template_node_names() {
+        let code = r#"{#if ready}
+    <p>ok</p>
+{/if}
+{#each items as item}
+    {@render row(item)}
+{/each}
+"#;
+
+        let audit = SvelteParserAudit::audit_code(code).unwrap();
+
+        assert!(audit.grammar_nodes.contains_key("if_statement"));
+        assert!(audit.grammar_nodes.contains_key("each_statement"));
+        assert!(audit.grammar_nodes.contains_key("render_tag"));
+    }
+}

--- a/src/parsing/svelte/behavior.rs
+++ b/src/parsing/svelte/behavior.rs
@@ -1,0 +1,57 @@
+//! Svelte language behavior
+
+use crate::parsing::LanguageBehavior;
+use crate::Visibility;
+use tree_sitter::Language;
+
+pub struct SvelteBehavior;
+
+impl SvelteBehavior {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for SvelteBehavior {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl LanguageBehavior for SvelteBehavior {
+    fn language_id(&self) -> crate::parsing::registry::LanguageId {
+        crate::parsing::registry::LanguageId::new("svelte")
+    }
+
+    fn format_module_path(&self, base_path: &str, _symbol_name: &str) -> String {
+        base_path.to_string()
+    }
+
+    fn module_separator(&self) -> &'static str {
+        "."
+    }
+
+    fn source_roots(&self) -> &'static [&'static str] {
+        &["src", "lib", "routes", "components", "pages"]
+    }
+
+    fn format_path_as_module(&self, components: &[&str]) -> Option<String> {
+        if components.is_empty() {
+            None
+        } else {
+            Some(components.join("."))
+        }
+    }
+
+    fn get_language(&self) -> Language {
+        tree_sitter_svelte_next::LANGUAGE.into()
+    }
+
+    fn parse_visibility(&self, signature: &str) -> Visibility {
+        if signature.contains("export ") {
+            Visibility::Public
+        } else {
+            Visibility::Private
+        }
+    }
+}

--- a/src/parsing/svelte/behavior.rs
+++ b/src/parsing/svelte/behavior.rs
@@ -1,7 +1,7 @@
 //! Svelte language behavior
 
-use crate::parsing::LanguageBehavior;
 use crate::Visibility;
+use crate::parsing::LanguageBehavior;
 use tree_sitter::Language;
 
 pub struct SvelteBehavior;

--- a/src/parsing/svelte/behavior.rs
+++ b/src/parsing/svelte/behavior.rs
@@ -1,7 +1,8 @@
 //! Svelte language behavior
 
-use crate::Visibility;
-use crate::parsing::LanguageBehavior;
+use super::resolution::{SvelteInheritanceResolver, SvelteResolutionContext};
+use crate::parsing::{InheritanceResolver, LanguageBehavior, ResolutionScope};
+use crate::{FileId, Visibility};
 use tree_sitter::Language;
 
 pub struct SvelteBehavior;
@@ -53,5 +54,13 @@ impl LanguageBehavior for SvelteBehavior {
         } else {
             Visibility::Private
         }
+    }
+
+    fn create_resolution_context(&self, file_id: FileId) -> Box<dyn ResolutionScope> {
+        Box::new(SvelteResolutionContext::new(file_id))
+    }
+
+    fn create_inheritance_resolver(&self) -> Box<dyn InheritanceResolver> {
+        Box::new(SvelteInheritanceResolver::new())
     }
 }

--- a/src/parsing/svelte/definition.rs
+++ b/src/parsing/svelte/definition.rs
@@ -1,0 +1,50 @@
+//! Svelte language definition and registration
+
+use crate::parsing::{
+    LanguageBehavior, LanguageDefinition, LanguageId, LanguageParser, LanguageRegistry,
+};
+use crate::{IndexError, IndexResult, Settings};
+use std::sync::Arc;
+
+use super::{SvelteBehavior, SvelteParser};
+
+pub struct SvelteLanguage;
+
+impl LanguageDefinition for SvelteLanguage {
+    fn id(&self) -> LanguageId {
+        LanguageId::new("svelte")
+    }
+
+    fn name(&self) -> &'static str {
+        "Svelte"
+    }
+
+    fn extensions(&self) -> &'static [&'static str] {
+        &["svelte"]
+    }
+
+    fn create_parser(&self, _settings: &Settings) -> IndexResult<Box<dyn LanguageParser>> {
+        let parser = SvelteParser::new().map_err(|e| IndexError::General(e.to_string()))?;
+        Ok(Box::new(parser))
+    }
+
+    fn create_behavior(&self) -> Box<dyn LanguageBehavior> {
+        Box::new(SvelteBehavior::new())
+    }
+
+    fn default_enabled(&self) -> bool {
+        true
+    }
+
+    fn is_enabled(&self, settings: &Settings) -> bool {
+        settings
+            .languages
+            .get("svelte")
+            .map(|config| config.enabled)
+            .unwrap_or(self.default_enabled())
+    }
+}
+
+pub(crate) fn register(registry: &mut LanguageRegistry) {
+    registry.register(Arc::new(SvelteLanguage));
+}

--- a/src/parsing/svelte/mod.rs
+++ b/src/parsing/svelte/mod.rs
@@ -6,5 +6,5 @@ pub mod parser;
 
 pub use behavior::SvelteBehavior;
 pub use definition::SvelteLanguage;
-pub use parser::SvelteParser;
 pub(crate) use definition::register;
+pub use parser::SvelteParser;

--- a/src/parsing/svelte/mod.rs
+++ b/src/parsing/svelte/mod.rs
@@ -1,0 +1,10 @@
+//! Svelte language parser implementation
+
+pub mod behavior;
+pub mod definition;
+pub mod parser;
+
+pub use behavior::SvelteBehavior;
+pub use definition::SvelteLanguage;
+pub use parser::SvelteParser;
+pub(crate) use definition::register;

--- a/src/parsing/svelte/mod.rs
+++ b/src/parsing/svelte/mod.rs
@@ -14,7 +14,9 @@
 //! - [`definition`]: language registration
 //! - [`resolution`]: symbol resolution, delegating to the JS resolver since
 //!   `<script>` blocks are JS/TS
+//! - [`audit`]: grammar node coverage tracking for the ABI audit pipeline
 
+pub mod audit;
 pub mod behavior;
 pub mod definition;
 pub mod parser;

--- a/src/parsing/svelte/mod.rs
+++ b/src/parsing/svelte/mod.rs
@@ -1,10 +1,28 @@
 //! Svelte language parser implementation
+//!
+//! Svelte files are HTML-shaped templates whose `<script>` blocks contain
+//! JavaScript or TypeScript. The parser locates each script block with the
+//! tree-sitter-svelte grammar and re-parses its body with the JS or TS parser
+//! (selected by the block's `lang` attribute), then maps ranges back to
+//! file-level positions. Template-level constructs handled directly include
+//! `{#snippet}` definitions.
+//!
+//! ## Module Components
+//!
+//! - [`parser`]: script extraction, JS/TS delegation, and snippet collection
+//! - [`behavior`]: Svelte-specific language behavior and resolution wiring
+//! - [`definition`]: language registration
+//! - [`resolution`]: symbol resolution, delegating to the JS resolver since
+//!   `<script>` blocks are JS/TS
 
 pub mod behavior;
 pub mod definition;
 pub mod parser;
+pub mod resolution;
 
 pub use behavior::SvelteBehavior;
 pub use definition::SvelteLanguage;
-pub(crate) use definition::register;
 pub use parser::SvelteParser;
+pub use resolution::{SvelteInheritanceResolver, SvelteResolutionContext};
+
+pub(crate) use definition::register;

--- a/src/parsing/svelte/parser.rs
+++ b/src/parsing/svelte/parser.rs
@@ -1,15 +1,17 @@
 //! Svelte language parser implementation
 //!
 //! Parses `.svelte` files by:
-//! 1. Using the tree-sitter-svelte grammar to locate `<script>` blocks
-//! 2. Re-parsing the script content with the JavaScript parser for symbol extraction
+//! 1. Using the tree-sitter-svelte grammar to locate every `<script>` block
+//!    (both the instance `<script>` and the module `<script module>`)
+//! 2. Re-parsing each script body with the JavaScript parser, or the TypeScript
+//!    parser when the block declares `lang="ts"` (the Svelte 5 default)
 //! 3. Offsetting all symbol ranges back to file-level positions
 //! 4. Extracting snippet function names directly from the Svelte AST
 
 use crate::parsing::import::Import;
 use crate::parsing::parser::check_recursion_depth;
 use crate::parsing::{
-    JavaScriptParser, LanguageParser, MethodCall, NodeTracker, NodeTrackingState,
+    JavaScriptParser, LanguageParser, MethodCall, NodeTracker, NodeTrackingState, TypeScriptParser,
 };
 use crate::types::SymbolCounter;
 use crate::{FileId, Range, Symbol, SymbolKind, Visibility};
@@ -20,9 +22,21 @@ use tree_sitter::{Language, Node, Parser};
 use crate::parsing::parser::HandledNode;
 use crate::parsing::registry::LanguageId;
 
+/// A `<script>` block located in a Svelte file, with the offset needed to map
+/// script-relative ranges back to file-level positions.
+struct ScriptBlock<'a> {
+    /// Raw script body (the `raw_text` between the script tags).
+    text: &'a str,
+    row_off: u32,
+    col_off: u16,
+    /// True when the block declares `lang="ts"` (or `lang="typescript"`).
+    is_typescript: bool,
+}
+
 pub struct SvelteParser {
     svelte_parser: Parser,
     js_parser: JavaScriptParser,
+    ts_parser: TypeScriptParser,
     node_tracker: NodeTrackingState,
 }
 
@@ -36,35 +50,89 @@ impl SvelteParser {
 
         let js_parser =
             JavaScriptParser::new().map_err(|e| format!("Failed to create JS sub-parser: {e}"))?;
+        let ts_parser =
+            TypeScriptParser::new().map_err(|e| format!("Failed to create TS sub-parser: {e}"))?;
 
         Ok(Self {
             svelte_parser,
             js_parser,
+            ts_parser,
             node_tracker: NodeTrackingState::new(),
         })
     }
 
-    /// Locate the first `<script>` block and return its raw text plus file-level position offset.
-    fn extract_script<'a>(&mut self, code: &'a str) -> Option<(&'a str, u32, u16)> {
-        let tree = self.svelte_parser.parse(code, None)?;
+    /// Locate every `<script>` block, returning each body plus its file-level
+    /// offset and whether it is TypeScript. Both the instance `<script>` and a
+    /// module `<script module>` block are returned, in document order.
+    fn extract_scripts<'a>(&mut self, code: &'a str) -> Vec<ScriptBlock<'a>> {
+        let Some(tree) = self.svelte_parser.parse(code, None) else {
+            return Vec::new();
+        };
         let root = tree.root_node();
 
+        let mut scripts = Vec::new();
         let mut root_cursor = root.walk();
         for child in root.children(&mut root_cursor) {
-            if child.kind() == "script_element" {
-                let mut child_cursor = child.walk();
-                for inner in child.children(&mut child_cursor) {
-                    if inner.kind() == "raw_text" {
-                        let row_off = inner.start_position().row as u32;
-                        let col_off = inner.start_position().column as u16;
-                        // SAFETY: byte_range is within code's bounds (same source)
-                        let script = &code[inner.byte_range()];
-                        return Some((script, row_off, col_off));
-                    }
+            if child.kind() != "script_element" {
+                continue;
+            }
+            self.register_handled_node(child.kind(), child.kind_id());
+            let is_typescript = Self::script_is_typescript(child, code);
+
+            let mut child_cursor = child.walk();
+            for inner in child.children(&mut child_cursor) {
+                if inner.kind() == "raw_text" {
+                    self.register_handled_node(inner.kind(), inner.kind_id());
+                    let row_off = inner.start_position().row as u32;
+                    let col_off = inner.start_position().column as u16;
+                    // SAFETY: byte_range is within code's bounds (same source)
+                    let text = &code[inner.byte_range()];
+                    scripts.push(ScriptBlock {
+                        text,
+                        row_off,
+                        col_off,
+                        is_typescript,
+                    });
                 }
             }
         }
-        None
+        scripts
+    }
+
+    /// Inspect a `script_element`'s start tag for a `lang="ts"` attribute.
+    fn script_is_typescript(script_element: Node, code: &str) -> bool {
+        let mut tag_cursor = script_element.walk();
+        for tag in script_element.children(&mut tag_cursor) {
+            if tag.kind() != "start_tag" {
+                continue;
+            }
+            let mut attr_cursor = tag.walk();
+            for attr in tag.children(&mut attr_cursor) {
+                if attr.kind() != "attribute" {
+                    continue;
+                }
+                let mut is_lang = false;
+                let mut is_ts = false;
+                let mut part_cursor = attr.walk();
+                for part in attr.children(&mut part_cursor) {
+                    match part.kind() {
+                        "attribute_name" => {
+                            is_lang = code[part.byte_range()].trim() == "lang";
+                        }
+                        "quoted_attribute_value" | "attribute_value" => {
+                            let value = code[part.byte_range()]
+                                .trim_matches(|c| c == '"' || c == '\'' || c == ' ');
+                            is_ts = value == "ts" || value == "typescript";
+                        }
+                        _ => {}
+                    }
+                }
+                if is_lang && is_ts {
+                    return true;
+                }
+            }
+        }
+        false
     }
 
     /// Adjust a script-relative `Range` to be relative to the whole file.
@@ -87,6 +155,7 @@ impl SvelteParser {
 
     /// Walk the Svelte AST for `snippet_statement` nodes and emit a Function symbol per snippet.
     fn collect_snippets(
+        &mut self,
         node: Node,
         code: &str,
         file_id: FileId,
@@ -99,12 +168,15 @@ impl SvelteParser {
         }
 
         if node.kind() == "snippet_statement" {
+            self.register_handled_node(node.kind(), node.kind_id());
             let mut c = node.walk();
             'outer: for child in node.children(&mut c) {
                 if child.kind() == "snippet_start" {
+                    self.register_handled_node(child.kind(), child.kind_id());
                     let mut c2 = child.walk();
                     for inner in child.children(&mut c2) {
                         if inner.kind() == "snippet_name" {
+                            self.register_handled_node(inner.kind(), inner.kind_id());
                             let name = code[inner.byte_range()].to_string();
                             let id = counter.next_id();
                             let range = Range::new(
@@ -127,7 +199,7 @@ impl SvelteParser {
 
         let mut c = node.walk();
         for child in node.children(&mut c) {
-            Self::collect_snippets(child, code, file_id, counter, out, depth + 1);
+            self.collect_snippets(child, code, file_id, counter, out, depth + 1);
         }
     }
 }
@@ -151,20 +223,24 @@ impl LanguageParser for SvelteParser {
     ) -> Vec<Symbol> {
         let mut symbols = Vec::new();
 
-        // Re-parse the script block with the JS parser and offset ranges.
-        if let Some((script, row_off, col_off)) = self.extract_script(code) {
-            let mut js_symbols = self.js_parser.parse(script, file_id, symbol_counter);
-            for sym in &mut js_symbols {
-                sym.range = Self::offset_range(sym.range, row_off, col_off);
+        // Re-parse each <script> block with the matching JS/TS parser and offset ranges.
+        for script in self.extract_scripts(code) {
+            let mut script_symbols = if script.is_typescript {
+                self.ts_parser.parse(script.text, file_id, symbol_counter)
+            } else {
+                self.js_parser.parse(script.text, file_id, symbol_counter)
+            };
+            for sym in &mut script_symbols {
+                sym.range = Self::offset_range(sym.range, script.row_off, script.col_off);
                 sym.language_id = Some(LanguageId::new("svelte"));
             }
-            symbols.extend(js_symbols);
+            symbols.extend(script_symbols);
         }
 
         // Collect snippet functions from the template.
         if let Some(tree) = self.svelte_parser.parse(code, None) {
             let root = tree.root_node();
-            Self::collect_snippets(root, code, file_id, symbol_counter, &mut symbols, 0);
+            self.collect_snippets(root, code, file_id, symbol_counter, &mut symbols, 0);
         }
 
         symbols
@@ -179,91 +255,133 @@ impl LanguageParser for SvelteParser {
     }
 
     fn find_calls<'a>(&mut self, code: &'a str) -> Vec<(&'a str, &'a str, Range)> {
-        let Some((script, row_off, col_off)) = self.extract_script(code) else {
-            return Vec::new();
-        };
-        self.js_parser
-            .find_calls(script)
-            .into_iter()
-            .map(|(caller, callee, r)| (caller, callee, Self::offset_range(r, row_off, col_off)))
-            .collect()
+        let mut out = Vec::new();
+        for script in self.extract_scripts(code) {
+            let calls = if script.is_typescript {
+                self.ts_parser.find_calls(script.text)
+            } else {
+                self.js_parser.find_calls(script.text)
+            };
+            out.extend(calls.into_iter().map(|(caller, callee, r)| {
+                (
+                    caller,
+                    callee,
+                    Self::offset_range(r, script.row_off, script.col_off),
+                )
+            }));
+        }
+        out
     }
 
     fn find_method_calls(&mut self, code: &str) -> Vec<MethodCall> {
-        let Some((script, row_off, col_off)) = self.extract_script(code) else {
-            return Vec::new();
-        };
-        self.js_parser
-            .find_method_calls(script)
-            .into_iter()
-            .map(|mut mc| {
-                mc.range = Self::offset_range(mc.range, row_off, col_off);
+        let mut out = Vec::new();
+        for script in self.extract_scripts(code) {
+            let calls = if script.is_typescript {
+                self.ts_parser.find_method_calls(script.text)
+            } else {
+                self.js_parser.find_method_calls(script.text)
+            };
+            out.extend(calls.into_iter().map(|mut mc| {
+                mc.range = Self::offset_range(mc.range, script.row_off, script.col_off);
                 mc
-            })
-            .collect()
+            }));
+        }
+        out
     }
 
     fn find_implementations<'a>(&mut self, code: &'a str) -> Vec<(&'a str, &'a str, Range)> {
-        let Some((script, row_off, col_off)) = self.extract_script(code) else {
-            return Vec::new();
-        };
-        self.js_parser
-            .find_implementations(script)
-            .into_iter()
-            .map(|(a, b, r)| (a, b, Self::offset_range(r, row_off, col_off)))
-            .collect()
+        let mut out = Vec::new();
+        for script in self.extract_scripts(code) {
+            let rels = if script.is_typescript {
+                self.ts_parser.find_implementations(script.text)
+            } else {
+                self.js_parser.find_implementations(script.text)
+            };
+            out.extend(
+                rels.into_iter()
+                    .map(|(a, b, r)| (a, b, Self::offset_range(r, script.row_off, script.col_off))),
+            );
+        }
+        out
     }
 
     fn find_extends<'a>(&mut self, code: &'a str) -> Vec<(&'a str, &'a str, Range)> {
-        let Some((script, row_off, col_off)) = self.extract_script(code) else {
-            return Vec::new();
-        };
-        self.js_parser
-            .find_extends(script)
-            .into_iter()
-            .map(|(a, b, r)| (a, b, Self::offset_range(r, row_off, col_off)))
-            .collect()
+        let mut out = Vec::new();
+        for script in self.extract_scripts(code) {
+            let rels = if script.is_typescript {
+                self.ts_parser.find_extends(script.text)
+            } else {
+                self.js_parser.find_extends(script.text)
+            };
+            out.extend(
+                rels.into_iter()
+                    .map(|(a, b, r)| (a, b, Self::offset_range(r, script.row_off, script.col_off))),
+            );
+        }
+        out
     }
 
     fn find_uses<'a>(&mut self, code: &'a str) -> Vec<(&'a str, &'a str, Range)> {
-        let Some((script, row_off, col_off)) = self.extract_script(code) else {
-            return Vec::new();
-        };
-        self.js_parser
-            .find_uses(script)
-            .into_iter()
-            .map(|(a, b, r)| (a, b, Self::offset_range(r, row_off, col_off)))
-            .collect()
+        let mut out = Vec::new();
+        for script in self.extract_scripts(code) {
+            let rels = if script.is_typescript {
+                self.ts_parser.find_uses(script.text)
+            } else {
+                self.js_parser.find_uses(script.text)
+            };
+            out.extend(
+                rels.into_iter()
+                    .map(|(a, b, r)| (a, b, Self::offset_range(r, script.row_off, script.col_off))),
+            );
+        }
+        out
     }
 
     fn find_defines<'a>(&mut self, code: &'a str) -> Vec<(&'a str, &'a str, Range)> {
-        let Some((script, row_off, col_off)) = self.extract_script(code) else {
-            return Vec::new();
-        };
-        self.js_parser
-            .find_defines(script)
-            .into_iter()
-            .map(|(a, b, r)| (a, b, Self::offset_range(r, row_off, col_off)))
-            .collect()
+        let mut out = Vec::new();
+        for script in self.extract_scripts(code) {
+            let rels = if script.is_typescript {
+                self.ts_parser.find_defines(script.text)
+            } else {
+                self.js_parser.find_defines(script.text)
+            };
+            out.extend(
+                rels.into_iter()
+                    .map(|(a, b, r)| (a, b, Self::offset_range(r, script.row_off, script.col_off))),
+            );
+        }
+        out
     }
 
     fn find_imports(&mut self, code: &str, file_id: FileId) -> Vec<Import> {
-        let Some((script, _row_off, _col_off)) = self.extract_script(code) else {
-            return Vec::new();
-        };
-        // Import has no range field, so no offset needed.
-        self.js_parser.find_imports(script, file_id)
+        let mut out = Vec::new();
+        for script in self.extract_scripts(code) {
+            // Import has no range field, so no offset needed.
+            let imports = if script.is_typescript {
+                self.ts_parser.find_imports(script.text, file_id)
+            } else {
+                self.js_parser.find_imports(script.text, file_id)
+            };
+            out.extend(imports);
+        }
+        out
     }
 
     fn find_variable_types<'a>(&mut self, code: &'a str) -> Vec<(&'a str, &'a str, Range)> {
-        let Some((script, row_off, col_off)) = self.extract_script(code) else {
-            return Vec::new();
-        };
-        self.js_parser
-            .find_variable_types(script)
-            .into_iter()
-            .map(|(a, b, r)| (a, b, Self::offset_range(r, row_off, col_off)))
-            .collect()
+        let mut out = Vec::new();
+        for script in self.extract_scripts(code) {
+            let types = if script.is_typescript {
+                self.ts_parser.find_variable_types(script.text)
+            } else {
+                self.js_parser.find_variable_types(script.text)
+            };
+            out.extend(
+                types
+                    .into_iter()
+                    .map(|(a, b, r)| (a, b, Self::offset_range(r, script.row_off, script.col_off))),
+            );
+        }
+        out
     }
 
     fn language(&self) -> crate::parsing::Language {
@@ -372,6 +490,78 @@ mod tests {
             imports.iter().any(|i| i.path.contains("math")),
             "should find math import; got: {:?}",
             imports.iter().map(|i| &i.path).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_typescript_script_symbols() {
+        // Svelte 5 defaults to `lang="ts"`; symbols must route through the TS parser.
+        let mut parser = SvelteParser::new().unwrap();
+        let mut counter = SymbolCounter::new();
+        let code = r#"<script lang="ts">
+    interface User {
+        name: string;
+    }
+
+    export function greet(user: User): string {
+        return `Hello ${user.name}`;
+    }
+</script>
+
+<h1>Hello</h1>
+"#;
+        let symbols = parser.parse(code, file_id(), &mut counter);
+        let names: Vec<&str> = symbols.iter().map(|s| s.name.as_ref()).collect();
+        assert!(
+            names.contains(&"greet"),
+            "should extract greet function from TS block; got: {names:?}"
+        );
+        assert!(
+            names.contains(&"User"),
+            "should extract User interface (TS-only construct); got: {names:?}"
+        );
+    }
+
+    #[test]
+    fn test_module_and_instance_scripts() {
+        // Both the module `<script module>` and the instance `<script>` must be parsed.
+        let mut parser = SvelteParser::new().unwrap();
+        let mut counter = SymbolCounter::new();
+        let code = r#"<script module>
+    export const VERSION = "1.0.0";
+</script>
+
+<script lang="ts">
+    export function start(): void {}
+</script>
+
+<p>{VERSION}</p>
+"#;
+        let symbols = parser.parse(code, file_id(), &mut counter);
+        let names: Vec<&str> = symbols.iter().map(|s| s.name.as_ref()).collect();
+        assert!(
+            names.contains(&"VERSION"),
+            "should extract VERSION from module script; got: {names:?}"
+        );
+        assert!(
+            names.contains(&"start"),
+            "should extract start from instance script; got: {names:?}"
+        );
+    }
+
+    #[test]
+    fn test_typescript_imports() {
+        let mut parser = SvelteParser::new().unwrap();
+        let code = r#"<script lang="ts">
+    import type { User } from './types.ts';
+    import { load } from './api.ts';
+</script>
+"#;
+        let imports = parser.find_imports(code, file_id());
+        let paths: Vec<&String> = imports.iter().map(|i| &i.path).collect();
+        assert!(
+            paths.iter().any(|p| p.contains("api")),
+            "should find api import from TS block; got: {paths:?}"
         );
     }
 }

--- a/src/parsing/svelte/parser.rs
+++ b/src/parsing/svelte/parser.rs
@@ -1,0 +1,377 @@
+//! Svelte language parser implementation
+//!
+//! Parses `.svelte` files by:
+//! 1. Using the tree-sitter-svelte grammar to locate `<script>` blocks
+//! 2. Re-parsing the script content with the JavaScript parser for symbol extraction
+//! 3. Offsetting all symbol ranges back to file-level positions
+//! 4. Extracting snippet function names directly from the Svelte AST
+
+use crate::parsing::import::Import;
+use crate::parsing::parser::check_recursion_depth;
+use crate::parsing::{
+    JavaScriptParser, LanguageParser, MethodCall, NodeTracker, NodeTrackingState,
+};
+use crate::types::SymbolCounter;
+use crate::{FileId, Range, Symbol, SymbolKind, Visibility};
+use std::any::Any;
+use std::collections::HashSet;
+use tree_sitter::{Language, Node, Parser};
+
+use crate::parsing::parser::HandledNode;
+use crate::parsing::registry::LanguageId;
+
+pub struct SvelteParser {
+    svelte_parser: Parser,
+    js_parser: JavaScriptParser,
+    node_tracker: NodeTrackingState,
+}
+
+impl SvelteParser {
+    pub fn new() -> Result<Self, String> {
+        let mut svelte_parser = Parser::new();
+        let language: Language = tree_sitter_svelte_next::LANGUAGE.into();
+        svelte_parser
+            .set_language(&language)
+            .map_err(|e| format!("Failed to set Svelte language: {e}"))?;
+
+        let js_parser =
+            JavaScriptParser::new().map_err(|e| format!("Failed to create JS sub-parser: {e}"))?;
+
+        Ok(Self {
+            svelte_parser,
+            js_parser,
+            node_tracker: NodeTrackingState::new(),
+        })
+    }
+
+    /// Locate the first `<script>` block and return its raw text plus file-level position offset.
+    fn extract_script<'a>(&mut self, code: &'a str) -> Option<(&'a str, u32, u16)> {
+        let tree = self.svelte_parser.parse(code, None)?;
+        let root = tree.root_node();
+
+        let mut root_cursor = root.walk();
+        for child in root.children(&mut root_cursor) {
+            if child.kind() == "script_element" {
+                let mut child_cursor = child.walk();
+                for inner in child.children(&mut child_cursor) {
+                    if inner.kind() == "raw_text" {
+                        let row_off = inner.start_position().row as u32;
+                        let col_off = inner.start_position().column as u16;
+                        // SAFETY: byte_range is within code's bounds (same source)
+                        let script = &code[inner.byte_range()];
+                        return Some((script, row_off, col_off));
+                    }
+                }
+            }
+        }
+        None
+    }
+
+    /// Adjust a script-relative `Range` to be relative to the whole file.
+    fn offset_range(r: Range, row_off: u32, col_off: u16) -> Range {
+        Range::new(
+            r.start_line + row_off,
+            if r.start_line == 0 {
+                r.start_column.saturating_add(col_off)
+            } else {
+                r.start_column
+            },
+            r.end_line + row_off,
+            if r.end_line == 0 {
+                r.end_column.saturating_add(col_off)
+            } else {
+                r.end_column
+            },
+        )
+    }
+
+    /// Walk the Svelte AST for `snippet_statement` nodes and emit a Function symbol per snippet.
+    fn collect_snippets(
+        node: Node,
+        code: &str,
+        file_id: FileId,
+        counter: &mut SymbolCounter,
+        out: &mut Vec<Symbol>,
+        depth: usize,
+    ) {
+        if !check_recursion_depth(depth, node) {
+            return;
+        }
+
+        if node.kind() == "snippet_statement" {
+            let mut c = node.walk();
+            'outer: for child in node.children(&mut c) {
+                if child.kind() == "snippet_start" {
+                    let mut c2 = child.walk();
+                    for inner in child.children(&mut c2) {
+                        if inner.kind() == "snippet_name" {
+                            let name = code[inner.byte_range()].to_string();
+                            let id = counter.next_id();
+                            let range = Range::new(
+                                inner.start_position().row as u32,
+                                inner.start_position().column as u16,
+                                inner.end_position().row as u32,
+                                inner.end_position().column as u16,
+                            );
+                            let mut sym =
+                                Symbol::new(id, name, SymbolKind::Function, file_id, range);
+                            sym.visibility = Visibility::Private;
+                            sym.language_id = Some(LanguageId::new("svelte"));
+                            out.push(sym);
+                            break 'outer;
+                        }
+                    }
+                }
+            }
+        }
+
+        let mut c = node.walk();
+        for child in node.children(&mut c) {
+            Self::collect_snippets(child, code, file_id, counter, out, depth + 1);
+        }
+    }
+}
+
+impl NodeTracker for SvelteParser {
+    fn get_handled_nodes(&self) -> &HashSet<HandledNode> {
+        self.node_tracker.get_handled_nodes()
+    }
+
+    fn register_handled_node(&mut self, node_kind: &str, node_id: u16) {
+        self.node_tracker.register_handled_node(node_kind, node_id);
+    }
+}
+
+impl LanguageParser for SvelteParser {
+    fn parse(
+        &mut self,
+        code: &str,
+        file_id: FileId,
+        symbol_counter: &mut SymbolCounter,
+    ) -> Vec<Symbol> {
+        let mut symbols = Vec::new();
+
+        // Re-parse the script block with the JS parser and offset ranges.
+        if let Some((script, row_off, col_off)) = self.extract_script(code) {
+            let mut js_symbols = self.js_parser.parse(script, file_id, symbol_counter);
+            for sym in &mut js_symbols {
+                sym.range = Self::offset_range(sym.range, row_off, col_off);
+                sym.language_id = Some(LanguageId::new("svelte"));
+            }
+            symbols.extend(js_symbols);
+        }
+
+        // Collect snippet functions from the template.
+        if let Some(tree) = self.svelte_parser.parse(code, None) {
+            let root = tree.root_node();
+            Self::collect_snippets(root, code, file_id, symbol_counter, &mut symbols, 0);
+        }
+
+        symbols
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn extract_doc_comment(&self, _node: &Node, _code: &str) -> Option<String> {
+        None
+    }
+
+    fn find_calls<'a>(&mut self, code: &'a str) -> Vec<(&'a str, &'a str, Range)> {
+        let Some((script, row_off, col_off)) = self.extract_script(code) else {
+            return Vec::new();
+        };
+        self.js_parser
+            .find_calls(script)
+            .into_iter()
+            .map(|(caller, callee, r)| (caller, callee, Self::offset_range(r, row_off, col_off)))
+            .collect()
+    }
+
+    fn find_method_calls(&mut self, code: &str) -> Vec<MethodCall> {
+        let Some((script, row_off, col_off)) = self.extract_script(code) else {
+            return Vec::new();
+        };
+        self.js_parser
+            .find_method_calls(script)
+            .into_iter()
+            .map(|mut mc| {
+                mc.range = Self::offset_range(mc.range, row_off, col_off);
+                mc
+            })
+            .collect()
+    }
+
+    fn find_implementations<'a>(&mut self, code: &'a str) -> Vec<(&'a str, &'a str, Range)> {
+        let Some((script, row_off, col_off)) = self.extract_script(code) else {
+            return Vec::new();
+        };
+        self.js_parser
+            .find_implementations(script)
+            .into_iter()
+            .map(|(a, b, r)| (a, b, Self::offset_range(r, row_off, col_off)))
+            .collect()
+    }
+
+    fn find_extends<'a>(&mut self, code: &'a str) -> Vec<(&'a str, &'a str, Range)> {
+        let Some((script, row_off, col_off)) = self.extract_script(code) else {
+            return Vec::new();
+        };
+        self.js_parser
+            .find_extends(script)
+            .into_iter()
+            .map(|(a, b, r)| (a, b, Self::offset_range(r, row_off, col_off)))
+            .collect()
+    }
+
+    fn find_uses<'a>(&mut self, code: &'a str) -> Vec<(&'a str, &'a str, Range)> {
+        let Some((script, row_off, col_off)) = self.extract_script(code) else {
+            return Vec::new();
+        };
+        self.js_parser
+            .find_uses(script)
+            .into_iter()
+            .map(|(a, b, r)| (a, b, Self::offset_range(r, row_off, col_off)))
+            .collect()
+    }
+
+    fn find_defines<'a>(&mut self, code: &'a str) -> Vec<(&'a str, &'a str, Range)> {
+        let Some((script, row_off, col_off)) = self.extract_script(code) else {
+            return Vec::new();
+        };
+        self.js_parser
+            .find_defines(script)
+            .into_iter()
+            .map(|(a, b, r)| (a, b, Self::offset_range(r, row_off, col_off)))
+            .collect()
+    }
+
+    fn find_imports(&mut self, code: &str, file_id: FileId) -> Vec<Import> {
+        let Some((script, _row_off, _col_off)) = self.extract_script(code) else {
+            return Vec::new();
+        };
+        // Import has no range field, so no offset needed.
+        self.js_parser.find_imports(script, file_id)
+    }
+
+    fn find_variable_types<'a>(&mut self, code: &'a str) -> Vec<(&'a str, &'a str, Range)> {
+        let Some((script, row_off, col_off)) = self.extract_script(code) else {
+            return Vec::new();
+        };
+        self.js_parser
+            .find_variable_types(script)
+            .into_iter()
+            .map(|(a, b, r)| (a, b, Self::offset_range(r, row_off, col_off)))
+            .collect()
+    }
+
+    fn language(&self) -> crate::parsing::Language {
+        crate::parsing::Language::Svelte
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{FileId, SymbolCounter};
+
+    fn file_id() -> FileId {
+        FileId::new(1).unwrap()
+    }
+
+    #[test]
+    fn test_svelte_parser_loads() {
+        let parser = SvelteParser::new();
+        assert!(parser.is_ok(), "SvelteParser should initialize");
+    }
+
+    #[test]
+    fn test_validate_grammar_node_kinds() {
+        let behavior = crate::parsing::svelte::SvelteBehavior::new();
+        use crate::parsing::LanguageBehavior;
+        assert!(
+            behavior.validate_node_kind("script_element"),
+            "script_element should exist in grammar"
+        );
+        assert!(
+            behavior.validate_node_kind("element"),
+            "element should exist in grammar"
+        );
+    }
+
+    #[test]
+    fn test_parse_script_symbols() {
+        let mut parser = SvelteParser::new().unwrap();
+        let mut counter = SymbolCounter::new();
+        let code = r#"<script>
+    export function greet(name) {
+        return `Hello ${name}`;
+    }
+
+    let count = 0;
+</script>
+
+<h1>Hello</h1>
+"#;
+        let symbols = parser.parse(code, file_id(), &mut counter);
+        assert!(
+            symbols.iter().any(|s| s.name.as_ref() == "greet"),
+            "should extract greet function; got: {:?}",
+            symbols.iter().map(|s| s.name.as_ref()).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_snippet_symbols() {
+        let mut parser = SvelteParser::new().unwrap();
+        let mut counter = SymbolCounter::new();
+        let code = r#"<script>
+    let items = [];
+</script>
+
+{#snippet card(item)}
+    <div>{item.name}</div>
+{/snippet}
+"#;
+        let symbols = parser.parse(code, file_id(), &mut counter);
+        assert!(
+            symbols.iter().any(|s| s.name.as_ref() == "card"),
+            "should extract snippet 'card'; got: {:?}",
+            symbols.iter().map(|s| s.name.as_ref()).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_range_offset() {
+        // Script starts at line 1 (0-indexed), col 0
+        let r = Range::new(0, 4, 0, 9); // line 0, col 4-9 in script
+        let offset = SvelteParser::offset_range(r, 1, 0);
+        assert_eq!(offset.start_line, 1);
+        assert_eq!(offset.start_column, 4);
+
+        // Multi-line symbol: line 2 in script → line 3 in file
+        let r2 = Range::new(2, 0, 4, 1);
+        let offset2 = SvelteParser::offset_range(r2, 1, 0);
+        assert_eq!(offset2.start_line, 3);
+        assert_eq!(offset2.end_line, 5);
+    }
+
+    #[test]
+    fn test_find_imports() {
+        let mut parser = SvelteParser::new().unwrap();
+        let code = r#"<script>
+    import { add } from './math.js';
+    import Component from './Component.svelte';
+</script>
+<Component />
+"#;
+        let fid = file_id();
+        let imports = parser.find_imports(code, fid);
+        assert!(
+            imports.iter().any(|i| i.path.contains("math")),
+            "should find math import; got: {:?}",
+            imports.iter().map(|i| &i.path).collect::<Vec<_>>()
+        );
+    }
+}

--- a/src/parsing/svelte/resolution.rs
+++ b/src/parsing/svelte/resolution.rs
@@ -1,0 +1,181 @@
+//! Svelte-specific resolution and inheritance implementation.
+//!
+//! Svelte components hold JavaScript or TypeScript inside their `<script>`
+//! blocks, so symbol resolution follows the exact same rules: hoisting of
+//! functions and `var` declarations, block scoping for `let`/`const`, and ES
+//! module semantics. Rather than duplicate that logic, the Svelte context wraps
+//! [`JavaScriptResolutionContext`] and forwards to it. This keeps Svelte aligned
+//! with the standard four-file parser layout (parser/behavior/definition/
+//! resolution) while reusing the battle-tested JS resolver.
+
+use crate::parsing::javascript::resolution::{
+    JavaScriptInheritanceResolver, JavaScriptResolutionContext,
+};
+use crate::parsing::resolution::ImportBinding;
+use crate::parsing::{InheritanceResolver, ResolutionScope, ScopeLevel, ScopeType};
+use crate::symbol::ScopeContext;
+use crate::{FileId, RelationKind, SymbolId, SymbolKind};
+use std::any::Any;
+
+/// Svelte resolution context.
+///
+/// Delegates to [`JavaScriptResolutionContext`]; see the module docs for why.
+pub struct SvelteResolutionContext {
+    inner: JavaScriptResolutionContext,
+}
+
+impl SvelteResolutionContext {
+    pub fn new(file_id: FileId) -> Self {
+        Self {
+            inner: JavaScriptResolutionContext::new(file_id),
+        }
+    }
+
+    /// Track an imported symbol (mirrors the JS context API).
+    pub fn add_import_symbol(&mut self, name: String, symbol_id: SymbolId, is_type_only: bool) {
+        self.inner.add_import_symbol(name, symbol_id, is_type_only);
+    }
+
+    /// Add a symbol using its scope context so hoisting/block-scoping apply.
+    pub fn add_symbol_with_context(
+        &mut self,
+        name: String,
+        symbol_id: SymbolId,
+        scope_context: Option<&ScopeContext>,
+    ) {
+        self.inner
+            .add_symbol_with_context(name, symbol_id, scope_context);
+    }
+}
+
+impl ResolutionScope for SvelteResolutionContext {
+    fn add_symbol(&mut self, name: String, symbol_id: SymbolId, scope_level: ScopeLevel) {
+        self.inner.add_symbol(name, symbol_id, scope_level);
+    }
+
+    fn resolve(&self, name: &str) -> Option<SymbolId> {
+        self.inner.resolve(name)
+    }
+
+    fn clear_local_scope(&mut self) {
+        self.inner.clear_local_scope();
+    }
+
+    fn enter_scope(&mut self, scope_type: ScopeType) {
+        self.inner.enter_scope(scope_type);
+    }
+
+    fn exit_scope(&mut self) {
+        self.inner.exit_scope();
+    }
+
+    fn symbols_in_scope(&self) -> Vec<(String, SymbolId, ScopeLevel)> {
+        self.inner.symbols_in_scope()
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+
+    fn resolve_relationship(
+        &self,
+        from_name: &str,
+        to_name: &str,
+        kind: RelationKind,
+        from_file: FileId,
+    ) -> Option<SymbolId> {
+        self.inner
+            .resolve_relationship(from_name, to_name, kind, from_file)
+    }
+
+    fn populate_imports(&mut self, imports: &[crate::parsing::Import]) {
+        self.inner.populate_imports(imports);
+    }
+
+    fn register_import_binding(&mut self, binding: ImportBinding) {
+        self.inner.register_import_binding(binding);
+    }
+
+    fn import_binding(&self, name: &str) -> Option<ImportBinding> {
+        self.inner.import_binding(name)
+    }
+
+    fn is_compatible_relationship(
+        &self,
+        from_kind: SymbolKind,
+        to_kind: SymbolKind,
+        rel_kind: RelationKind,
+    ) -> bool {
+        self.inner
+            .is_compatible_relationship(from_kind, to_kind, rel_kind)
+    }
+}
+
+/// Svelte inheritance resolver.
+///
+/// Class inheritance inside `<script>` blocks is plain JS/TS `extends`, so this
+/// forwards to [`JavaScriptInheritanceResolver`].
+#[derive(Default)]
+pub struct SvelteInheritanceResolver {
+    inner: JavaScriptInheritanceResolver,
+}
+
+impl SvelteInheritanceResolver {
+    pub fn new() -> Self {
+        Self {
+            inner: JavaScriptInheritanceResolver::new(),
+        }
+    }
+}
+
+impl InheritanceResolver for SvelteInheritanceResolver {
+    fn add_inheritance(&mut self, child: String, parent: String, kind: &str) {
+        self.inner.add_inheritance(child, parent, kind);
+    }
+
+    fn resolve_method(&self, type_name: &str, method: &str) -> Option<String> {
+        self.inner.resolve_method(type_name, method)
+    }
+
+    fn get_inheritance_chain(&self, type_name: &str) -> Vec<String> {
+        self.inner.get_inheritance_chain(type_name)
+    }
+
+    fn is_subtype(&self, child: &str, parent: &str) -> bool {
+        self.inner.is_subtype(child, parent)
+    }
+
+    fn add_type_methods(&mut self, type_name: String, methods: Vec<String>) {
+        self.inner.add_type_methods(type_name, methods);
+    }
+
+    fn get_all_methods(&self, type_name: &str) -> Vec<String> {
+        self.inner.get_all_methods(type_name)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_svelte_resolution_delegates_to_js() {
+        let file_id = FileId::new(1).unwrap();
+        let mut context = SvelteResolutionContext::new(file_id);
+
+        let sym = SymbolId::new(1).unwrap();
+        context.add_symbol("greet".to_string(), sym, ScopeLevel::Module);
+
+        assert_eq!(context.resolve("greet"), Some(sym));
+        assert_eq!(context.resolve("missing"), None);
+    }
+
+    #[test]
+    fn test_svelte_inheritance_delegates_to_js() {
+        let mut resolver = SvelteInheritanceResolver::new();
+        resolver.add_inheritance("Child".to_string(), "Parent".to_string(), "extends");
+
+        assert!(resolver.is_subtype("Child", "Parent"));
+        assert!(!resolver.is_subtype("Parent", "Child"));
+    }
+}

--- a/tests/exploration/abi15_grammar_audit/mod.rs
+++ b/tests/exploration/abi15_grammar_audit/mod.rs
@@ -32,5 +32,6 @@ mod lua;
 mod php;
 mod python;
 mod rust_lang;
+mod svelte;
 mod swift;
 mod typescript;

--- a/tests/exploration/abi15_grammar_audit/svelte.rs
+++ b/tests/exploration/abi15_grammar_audit/svelte.rs
@@ -1,0 +1,96 @@
+//! Svelte grammar audit.
+
+use super::helpers::{AuditData, LanguageAuditConfig, run_comprehensive_analysis};
+use codanna::parsing::svelte::audit::SvelteParserAudit;
+
+const CONFIG: LanguageAuditConfig = LanguageAuditConfig {
+    language_name: "Svelte",
+    file_extension: "svelte",
+    grammar_json_path: "contributing/parsers/svelte/node-types.json",
+    example_file_path: "examples/svelte/comprehensive.svelte",
+    output_dir: "contributing/parsers/svelte",
+};
+
+fn node_categories() -> Vec<(&'static str, Vec<&'static str>)> {
+    vec![
+        (
+            "SCRIPT NODES",
+            vec![
+                "script_element",
+                "style_element",
+                "start_tag",
+                "end_tag",
+                "raw_text",
+            ],
+        ),
+        (
+            "ATTRIBUTE NODES",
+            vec![
+                "attribute",
+                "attribute_name",
+                "attribute_value",
+                "quoted_attribute_value",
+            ],
+        ),
+        (
+            "ELEMENT NODES",
+            vec!["element", "self_closing_tag", "tag_name", "text", "doctype"],
+        ),
+        (
+            "EXPRESSION NODES",
+            vec![
+                "expression",
+                "expression_tag",
+                "render_tag",
+                "html_tag",
+                "const_tag",
+                "debug_tag",
+                "svelte_raw_text",
+            ],
+        ),
+        (
+            "BLOCK NODES",
+            vec![
+                "if_statement",
+                "each_statement",
+                "await_statement",
+                "key_statement",
+                "block_start_tag",
+                "block_end_tag",
+                "else_block",
+            ],
+        ),
+        (
+            "SNIPPET NODES",
+            vec![
+                "snippet_statement",
+                "snippet_start",
+                "snippet_name",
+                "snippet_end",
+            ],
+        ),
+        ("COMMENT NODES", vec!["comment"]),
+    ]
+}
+
+#[test]
+fn comprehensive_svelte_analysis() {
+    run_comprehensive_analysis(
+        &CONFIG,
+        tree_sitter_svelte_next::LANGUAGE.into(),
+        "<script>let x = 1;</script>\n<p>{x}</p>\n",
+        &node_categories(),
+        |path| {
+            let audit = SvelteParserAudit::audit_file(path).map_err(|e| e.to_string())?;
+            let report = audit.generate_report();
+            Ok((
+                AuditData::new(
+                    audit.grammar_nodes,
+                    audit.implemented_nodes,
+                    audit.extracted_symbol_kinds,
+                ),
+                report,
+            ))
+        },
+    );
+}


### PR DESCRIPTION
## Summary

- Adds `.svelte` file support via a new `SvelteParser` that uses `tree-sitter-svelte-next` to locate `<script>` blocks and re-parses their content with the existing `JavaScriptParser`
- All symbol ranges are offset back to file-level positions so line/column numbers refer to the `.svelte` file, not the script fragment
- Svelte 5 `{#snippet name(...)}` blocks are detected directly in the Svelte AST and emitted as `Function` symbols
- New crate: `tree-sitter-svelte-next = "0.1.1"`

## Files changed

| File | Role |
|---|---|
| `src/parsing/svelte/parser.rs` | Core parser — script extraction, range offsetting, snippet collection, all `find_*` delegation to JS sub-parser |
| `src/parsing/svelte/behavior.rs` | `LanguageBehavior` — visibility via `export`, source roots for SvelteKit layout |
| `src/parsing/svelte/definition.rs` | `LanguageDefinition` registration, `is_enabled()` config check |
| `src/parsing/svelte/mod.rs` | Module re-exports + `register()` |
| `src/parsing/language.rs` | `Language::Svelte` enum variant + `extensions`, `config_key`, `name` |
| `src/parsing/mod.rs` | `pub mod svelte` + re-exports |
| `src/parsing/registry.rs` | `super::svelte::register(registry)` in `initialize_registry()` |
| `src/parsing/factory.rs` | `Language::Svelte` match arm in `create_parser_with_behavior()` and `enabled_languages()` |

## Design notes

**Why re-parse with JavaScriptParser instead of walking the Svelte tree?**
The `tree-sitter-svelte-next` grammar represents `<script>` content as an opaque `raw_text` node — there is no embedded JS/TS subtree. Re-parsing the raw text with `JavaScriptParser` reuses all existing JS symbol extraction, call/import/method-call logic, and future improvements for free.

**Range offset**: `raw_text.start_position()` gives the file-level row/column where the script begins. Every range produced by the JS sub-parser is shifted by this offset. Only the first line of a multi-line symbol gets the column offset applied (subsequent lines start at column 0 in the source).

## Test results

Tested against 11 real `.svelte` files from two GitHub projects (`svelte-realworld` and `svelte/examples`). All files parsed with **zero tree-sitter errors**.

### Assertions (all PASSED ✓)

```
=== Range offset verification ===
  [Function] 'hello' at file line 2  → expected 2 ✓
  [Variable] 'x'     at file line 3  → expected 3 ✓

=== Snippet detection verification ===
  Snippet 'greet' at file line 4     → expected 4 ✓

=== Counter.svelte function extraction ===
  [Function] 'increment' at file line 12  → expected 12 ✓
  [Function] 'decrement' at file line 17  → expected 17 ✓
```

### Symbol extraction summary

| File | Extracted symbols |
|---|---|
| `Nav.svelte` | 1 import (`$app/state`) |
| `Pagination.svelte` | `range` (Constant), `result` (Constant), `i` (Variable) |
| `+layout.svelte` | 4 imports |
| `+page.svelte` (realworld) | 3 imports, 4 constants |
| `Counter.svelte` (svelte 5) | 1 import, `increment` (Function), `decrement` (Function) |
| `+page.svelte` (todomvc) | 6 imports, 15 variables/constants |
| `+page.svelte` (file-uploads) | 7 imports, 7 variables/constants, `handle_large_submit` (Function) |

### Note on in-crate unit tests — ✅ resolved

~`src/parsing/svelte/parser.rs` contains 5 unit tests (`test_svelte_parser_loads`, `test_validate_grammar_node_kinds`, `test_parse_script_symbols`, `test_snippet_symbols`, `test_range_offset`). These cannot run locally because `sysinfo@0.39.2` (an existing dependency) requires rustc 1.95+, while the current Nix flake provides 1.94.0. The tests are expected to pass once the flake toolchain is updated.~

Resolved in 67e49ee — `rust-overlay` bumped to rustc 1.95.0. All Svelte parser tests pass under `nix develop --command cargo test --lib parsing::svelte::parser` (9 passed, 0 failed).
