### PR TITLE
Fixes the issue of failing to save semantic vectors when performing forced indexing for a large code repository on Windows 11.

### DIFF
--- a/src/semantic/simple.rs
+++ b/src/semantic/simple.rs
@@ -549,12 +549,18 @@ impl SimpleSemanticSearch {
         // Save all embeddings
         storage.save_batch(&embeddings)?;
 
+        // Release storage-owned handles or mappings before syncing and
+        // replacing the staged file. Important on Windows.
+        drop(storage);
+
         let staged_vec = staging_dir.join("segment_0.vec");
-        std::fs::File::open(&staged_vec)
+        std::fs::OpenOptions::new()
+            .write(true)
+            .open(&staged_vec)
             .and_then(|f| f.sync_all())
             .map_err(|e| SemanticSearchError::StorageError {
                 message: format!("Failed to sync staged vector file: {e}"),
-                suggestion: "Check disk space".to_string(),
+                suggestion: "Check disk space and staged-file write access".to_string(),
             })?;
         std::fs::rename(&staged_vec, path.join("segment_0.vec")).map_err(|e| {
             SemanticSearchError::StorageError {


### PR DESCRIPTION
## Summary

On Windows, `codanna index . --force` fails at the final semantic-save step with:

```
ERROR pipeline: Failed to save embeddings: Storage error: Failed to sync staged vector file: Access is denied. (os error 5)
Suggestion: Check disk space
```

This happens after embedding, indexing, and relationship resolution all complete successfully, so it wastes a full (~20 min) run right at the persistence stage. It is not caused by disk space, directory ACLs, a read-only attribute, or lack of Administrator privileges.

## Environment

- Codanna: `v0.9.23`
- OS: Windows 11 Pro x64
- Shell: PowerShell 7.6.3 / Windows Terminal
- Hardware: 20 logical CPUs, 32 GB RAM
- Repo indexed: ~30k files, ~140k embeddings

## Root cause

In `src/semantic/simple.rs`, the staged vector file is reopened read-only and then `sync_all()` is called on it:

```rust
std::fs::File::open(&staged_vec)
    .and_then(|f| f.sync_all())
```

`File::open()` requests `GENERIC_READ` only. On Windows, Rust maps `sync_all()` to the Win32 `FlushFileBuffers()` API, which requires a handle with `GENERIC_WRITE`. A read-only handle does not have it, so Windows returns `EROR_ACCESS_DENIED` (os error 5).

This is deterministic on Windows and is a regression introduced in `v0.9.23` by the atomic-save change (`58b9d fix(cleanup): atomic semantic saves; rollback Tantivy on error`). `v0.9.22` did not contain this staged-file sync path. 

A native Win32 probe against the real `segment_0.vec` confirmed the behavior:

```
read-only handle  + FlushFileBuffers -> win32=5 (Access denied)
writable handle   + FlushFileBuffers -> success
```

## Fix

Open the staged file with write access before syncing, and drop the storage handle before syncing/renaming so no storage-owned handle or mapping blocks the file on Windows:

```diff
         // Save all embeddings
         storage.save_batch(&embeddings)?;
+        // Release storage-owned handles or mappings before syncing and
+        // replacing the staged file. This is especially important on Windows.
+        drop(storage);

         let staged_vec = staging_dir.join("segment_0.vec");
-        std::fs::File::open(&staged_vec)
+        std::fs::OpenOptions::new()
+            .write(true)
+            .open(&staged_vec)
             .and_then(|f| f.sync_all())
             .map_err(|e| SemanticSearchError::StorageError {
                 message: format!("Failed to sync staged vector file: {e}"),
-                suggestion: "Check disk space".to_string(),
+                suggestion: "Check disk space and staged-file write access".to_string(),
             })?;
```

The essential change is opening the file writable. The `drop(storage)` is not strictly required for this specific error but hardens the subsequent sync/rename step on Windows.

## Testing

- Verified on Windows 11 (NTFS): `codanna index . --force` now completes in a normal (non-Administrator) PowerShell 7 terminal with no  `Failed to sync staged vector file` error.
- `.staging` is cleaned up, and `segment_0.vec`, `metadata.json`,  `languages.json`, and `index.meta` are all produced.
- Semantic queries (with and without language filter) return results.