### PR TITLE
feat(serve): proxy mode with HTTP/HTTPS backing-server discovery

### DIFF
--- a/.claude/checkmate.json
+++ b/.claude/checkmate.json
@@ -1,0 +1,58 @@
+{
+  "environments": [
+    {
+      "name": "conduct",
+      "paths": [
+        "conduct"
+      ],
+      "checks": {
+        ".md": [
+          {
+            "name": "conduct",
+            "command": "node",
+            "args": [
+              "conduct/resources/scripts/validate-documents.mjs",
+              "--file",
+              "$FILE",
+              "--json"
+            ],
+            "parser": "jsonl",
+            "_conduct": true
+          }
+        ]
+      },
+      "_conduct": true
+    },
+    {
+      "name": "rust",
+      "paths": [
+        "."
+      ],
+      "checks": {
+        ".rs": [
+          {
+            "name": "rustfmt",
+            "command": "rustfmt",
+            "args": [
+              "--check",
+              "--edition",
+              "2024",
+              "$FILE"
+            ],
+            "parser": "prettier",
+            "_auto": true
+          }
+        ]
+      }
+    }
+  ],
+  "tasks": [
+    {
+      "name": "policy-reviewer",
+      "match": "conduct:policy-engineer",
+      "action": "review",
+      "message": "Invoke conduct:policy-reviewer to validate the policy file.",
+      "_conduct": true
+    }
+  ]
+}

--- a/.claude/conduct.json
+++ b/.claude/conduct.json
@@ -1,0 +1,54 @@
+{
+  "version": 3,
+  "pluginVersion": "1.54.3",
+  "conductProjectPath": "${CONDUCT_PROJECT_ROOT}/rcrsr-codanna",
+  "updated": "2026-07-14T00:15:03.168Z",
+  "domains": {
+    "CDNA": {
+      "name": "Codanna",
+      "policy": "conduct/policies/policy-domain-cdna.md",
+      "artifacts": [
+        "RS"
+      ],
+      "keywords": [
+        "rust",
+        "mcp",
+        "tree-sitter",
+        "tantivy",
+        "code-intelligence"
+      ],
+      "agents": {
+        "engineer": "codanna-engineer",
+        "code-reviewer": "codanna-code-reviewer",
+        "architect": "codanna-architect",
+        "spec-reviewer": "codanna-spec-reviewer"
+      }
+    }
+  },
+  "artifacts": {
+    "RS": {
+      "type": "generic",
+      "name": "Rust",
+      "policy": "policy-artifact-rust.md"
+    }
+  },
+  "products": {},
+  "explorers": [
+    {
+      "name": "project-explorer",
+      "description": "Codebase exploration with domain knowledge from §CDNA"
+    }
+  ],
+  "resources": {
+    "installed": "2026-07-13T23:26:05.901Z"
+  },
+  "bashSafety": {
+    "enabled": true,
+    "disabledPatterns": [],
+    "additionalPatterns": [],
+    "additionalExceptions": {
+      "paths": [],
+      "commands": []
+    }
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,7 @@ vendors/fastembed-rs
 !/scripts/install.sh
 !/scripts/install.ps1
 docs/
+
+internal/
+conduct
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -773,7 +773,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "codanna"
-version = "0.9.23+rcrsr"
+version = "0.9.23+rcrsr.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -773,7 +773,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "codanna"
-version = "0.9.23"
+version = "0.9.23-rcrsr"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -773,7 +773,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "codanna"
-version = "0.9.23-rcrsr"
+version = "0.9.23+rcrsr"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -806,7 +806,8 @@ dependencies = [
  "rayon",
  "rcgen",
  "regex",
- "reqwest",
+ "reqwest 0.12.28",
+ "reqwest 0.13.4",
  "rmcp",
  "rustls",
  "serde",
@@ -857,6 +858,16 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
 
 [[package]]
 name = "comfy-table"
@@ -1904,7 +1915,7 @@ dependencies = [
  "log",
  "native-tls",
  "rand 0.9.2",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "thiserror",
@@ -2440,6 +2451,55 @@ name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "jobserver"
@@ -3932,9 +3992,48 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.4.2",
  "web-sys",
  "webpki-roots 1.0.6",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tower",
+ "tower-http 0.6.11",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams 0.5.0",
+ "web-sys",
 ]
 
 [[package]]
@@ -3975,6 +4074,7 @@ dependencies = [
  "pin-project-lite",
  "process-wrap",
  "rand 0.10.2",
+ "reqwest 0.13.4",
  "rmcp-macros",
  "schemars 1.2.1",
  "serde",
@@ -4017,6 +4117,15 @@ name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rusticata-macros"
@@ -4076,6 +4185,33 @@ dependencies = [
  "web-time",
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -4404,6 +4540,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
 name = "simd_helpers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4411,6 +4557,12 @@ checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
 dependencies = [
  "quote",
 ]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "sketches-ddsketch"
@@ -5814,6 +5966,19 @@ name = "wasm-streams"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
 dependencies = [
  "futures-util",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,10 @@ notify = "8.2.0"
 num_cpus = "1.17.0"
 parking_lot = "0.12.5"
 rayon = "1.12.0"
-rmcp = { version = "2.1.0", features = ["server", "client", "transport-io", "transport-child-process", "transport-streamable-http-server", "transport-worker"] }
+# transport-streamable-http-client-reqwest gives the stdio<->HTTP proxy (src/mcp/proxy.rs) a
+# reqwest::Client that implements rmcp's StreamableHttpClient trait, so it can dial the loopback
+# backing "codanna serve --http" without a hand-rolled HTTP client (pulls in rmcp's own reqwest dep).
+rmcp = { version = "2.1.0", features = ["server", "client", "transport-io", "transport-child-process", "transport-streamable-http-server", "transport-streamable-http-client", "transport-streamable-http-client-reqwest", "transport-worker"] }
 serde = { version = "1.0.228", features = ["derive", "rc"] }
 serde_json = "1.0.150"
 sha2 = "0.11.0"
@@ -103,6 +106,10 @@ tree-sitter-clojure-orchard = "0.2.5"
 glob = "0.3.3"
 async-trait = "0.1.89"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+# rmcp's `impl StreamableHttpClient for reqwest::Client` is against reqwest 0.13
+# (rmcp 2.1.0 -> reqwest 0.13.4). The 0.12 dep above is a DIFFERENT crate instance
+# and its Client does not implement that trait. Renamed so both can coexist.
+rmcp_reqwest = { package = "reqwest", version = "0.13", default-features = false }
 sysinfo = "0.39.5"
 indexmap = { version = "2.14.0", features = ["serde"] }
 
@@ -115,7 +122,28 @@ thread-id = "5.1.0"
 [features]
 default = ["http-server"]
 http-server = ["axum", "tower", "tower-http"]
-https-server = ["http-server", "axum-server", "rustls", "rcgen"]
+# reqwest 0.13's `rustls` feature selects aws-lc-rs as the crypto provider. codanna
+# pins `rustls` (above) to `ring` only. If rmcp_reqwest also enabled aws-lc-rs, two
+# competing default CryptoProviders would coexist in the same rustls instance, and
+# CryptoProvider::get_default_or_install_from_crate_features() would return None,
+# causing a runtime panic in `serve --https` and in semantic/remote.rs. Use
+# `rustls-no-provider` (no bundled crypto backend) so `ring` (pinned above) remains
+# the sole provider. Do NOT change this to `rustls`.
+#
+# `rmcp_reqwest/rustls-no-provider` is required by `serve_tls::pinned_client`
+# (the cert-pinned client used to dial a `--https` backing server), which calls
+# `ClientBuilder::tls_certs_only`, gated behind reqwest's `__tls` feature --
+# without a TLS backend enabled here that method does not exist at all. Wiring
+# this feature in requires the one-time
+# `rustls::crypto::ring::default_provider().install_default()` call described
+# above, or every `reqwest::Client` built through rmcp's streamable-HTTP
+# transport (including the plain `--http` proxy path, which never touches
+# `serve_tls`) panics with "No rustls crypto provider is configured" the first
+# time one is built in the process. `main.rs` makes that install call, once,
+# before any command dispatch, so every `reqwest::Client` construction site in
+# the process is covered by the same installed provider, whether it is built
+# via `serve --https`, the stdio<->HTTP proxy, or `serve_tls::pinned_client`.
+https-server = ["http-server", "axum-server", "rustls", "rcgen", "rmcp_reqwest/rustls-no-provider"]
 axum = ["dep:axum"]
 tower = ["dep:tower"]
 tower-http = ["dep:tower-http"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codanna"
-version = "0.9.23"
+version = "0.9.23-rcrsr"
 authors = ["Angel Bartolli <bartolli@gmail.com>"]
 edition = "2024"
 description = "Code Intelligence for Large Language Models"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codanna"
-version = "0.9.23-rcrsr"
+version = "0.9.23+rcrsr"
 authors = ["Angel Bartolli <bartolli@gmail.com>"]
 edition = "2024"
 description = "Code Intelligence for Large Language Models"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,22 @@
 [package]
 name = "codanna"
-version = "0.9.23+rcrsr"
+# Fork version: <upstream base>+rcrsr.<private addition counter>
+#
+#   0.9.23   -- the upstream release this fork is built from. Bump ONLY when
+#               rebasing/merging onto a new upstream release, and reset the
+#               counter to .1 when you do.
+#   +rcrsr.N -- N increments once per private addition landed on top of that
+#               base. Surfaces in `codanna --version` and, via
+#               CARGO_PKG_VERSION, in the MCP `initialize` handshake, so a
+#               connected client reports exactly which build it is talking to.
+#
+# `+` is BUILD METADATA, which semver ignores in precedence: every +rcrsr.N
+# compares EQUAL to a bare 0.9.23, and +rcrsr.7 does NOT sort above +rcrsr.1.
+# That is deliberate -- a `-rcrsr` pre-release would instead sort BELOW 0.9.23,
+# making a fork with strictly more code compare as older than the upstream it
+# was built from. The counter is informational, not orderable. Do not rely on
+# it for version-range gating.
+version = "0.9.23+rcrsr.1"
 authors = ["Angel Bartolli <bartolli@gmail.com>"]
 edition = "2024"
 description = "Code Intelligence for Large Language Models"

--- a/contributing/parsers/c/AUDIT_REPORT.md
+++ b/contributing/parsers/c/AUDIT_REPORT.md
@@ -1,7 +1,5 @@
 # C Parser Coverage Report
 
-*Generated: 2026-07-14 21:19:18 UTC*
-
 ## Summary
 - Key nodes: 19/21 (90%)
 - Symbol kinds extracted: 6

--- a/contributing/parsers/c/AUDIT_REPORT.md
+++ b/contributing/parsers/c/AUDIT_REPORT.md
@@ -1,6 +1,6 @@
 # C Parser Coverage Report
 
-*Generated: 2026-07-01 23:18:07 UTC*
+*Generated: 2026-07-14 21:19:18 UTC*
 
 ## Summary
 - Key nodes: 19/21 (90%)

--- a/contributing/parsers/c/GRAMMAR_ANALYSIS.md
+++ b/contributing/parsers/c/GRAMMAR_ANALYSIS.md
@@ -1,6 +1,6 @@
 # C Grammar Analysis
 
-*Generated: 2026-07-01 23:18:07 UTC*
+*Generated: 2026-07-14 21:19:18 UTC*
 
 ## Statistics
 - Total nodes in grammar JSON: 132

--- a/contributing/parsers/c/GRAMMAR_ANALYSIS.md
+++ b/contributing/parsers/c/GRAMMAR_ANALYSIS.md
@@ -1,7 +1,5 @@
 # C Grammar Analysis
 
-*Generated: 2026-07-14 21:19:18 UTC*
-
 ## Statistics
 - Total nodes in grammar JSON: 132
 - Nodes found in comprehensive.c: 145

--- a/contributing/parsers/c/node_discovery.txt
+++ b/contributing/parsers/c/node_discovery.txt
@@ -1,5 +1,4 @@
 === C Language NODE MAPPING ===
-  Generated: 2026-07-14 21:19:18 UTC
   ABI Version: 15
   Node kind count: 145
 

--- a/contributing/parsers/c/node_discovery.txt
+++ b/contributing/parsers/c/node_discovery.txt
@@ -1,5 +1,5 @@
 === C Language NODE MAPPING ===
-  Generated: 2026-07-01 23:18:07 UTC
+  Generated: 2026-07-14 21:19:18 UTC
   ABI Version: 15
   Node kind count: 145
 

--- a/contributing/parsers/clojure/AUDIT_REPORT.md
+++ b/contributing/parsers/clojure/AUDIT_REPORT.md
@@ -1,6 +1,6 @@
 # Clojure Parser Symbol Extraction Coverage Report
 
-*Generated: 2026-07-01 23:18:07 UTC*
+*Generated: 2026-07-14 21:19:18 UTC*
 
 ## Summary
 - Key nodes: 15/15 (100%)

--- a/contributing/parsers/clojure/AUDIT_REPORT.md
+++ b/contributing/parsers/clojure/AUDIT_REPORT.md
@@ -1,7 +1,5 @@
 # Clojure Parser Symbol Extraction Coverage Report
 
-*Generated: 2026-07-14 21:19:18 UTC*
-
 ## Summary
 - Key nodes: 15/15 (100%)
 - Symbol kinds extracted: 7

--- a/contributing/parsers/clojure/GRAMMAR_ANALYSIS.md
+++ b/contributing/parsers/clojure/GRAMMAR_ANALYSIS.md
@@ -1,6 +1,6 @@
 # Clojure Grammar Analysis
 
-*Generated: 2026-07-01 23:18:07 UTC*
+*Generated: 2026-07-14 21:19:18 UTC*
 
 ## Statistics
 - Total nodes in grammar JSON: 35

--- a/contributing/parsers/clojure/GRAMMAR_ANALYSIS.md
+++ b/contributing/parsers/clojure/GRAMMAR_ANALYSIS.md
@@ -1,7 +1,5 @@
 # Clojure Grammar Analysis
 
-*Generated: 2026-07-14 21:19:18 UTC*
-
 ## Statistics
 - Total nodes in grammar JSON: 35
 - Nodes found in comprehensive.clj: 56

--- a/contributing/parsers/clojure/node_discovery.txt
+++ b/contributing/parsers/clojure/node_discovery.txt
@@ -1,5 +1,5 @@
 === Clojure Language NODE MAPPING ===
-  Generated: 2026-07-01 23:18:07 UTC
+  Generated: 2026-07-14 21:19:18 UTC
   ABI Version: 14
   Node kind count: 56
 

--- a/contributing/parsers/clojure/node_discovery.txt
+++ b/contributing/parsers/clojure/node_discovery.txt
@@ -1,5 +1,4 @@
 === Clojure Language NODE MAPPING ===
-  Generated: 2026-07-14 21:19:18 UTC
   ABI Version: 14
   Node kind count: 56
 

--- a/contributing/parsers/cpp/AUDIT_REPORT.md
+++ b/contributing/parsers/cpp/AUDIT_REPORT.md
@@ -1,7 +1,5 @@
 # C++ Parser Coverage Report
 
-*Generated: 2026-07-14 21:19:18 UTC*
-
 ## Summary
 - Key nodes: 26/26 (100%)
 - Symbol kinds extracted: 5

--- a/contributing/parsers/cpp/AUDIT_REPORT.md
+++ b/contributing/parsers/cpp/AUDIT_REPORT.md
@@ -1,6 +1,6 @@
 # C++ Parser Coverage Report
 
-*Generated: 2026-07-01 23:18:07 UTC*
+*Generated: 2026-07-14 21:19:18 UTC*
 
 ## Summary
 - Key nodes: 26/26 (100%)

--- a/contributing/parsers/cpp/GRAMMAR_ANALYSIS.md
+++ b/contributing/parsers/cpp/GRAMMAR_ANALYSIS.md
@@ -1,7 +1,5 @@
 # C++ Grammar Analysis
 
-*Generated: 2026-07-14 21:19:18 UTC*
-
 ## Statistics
 - Total nodes in grammar JSON: 223
 - Nodes found in comprehensive.cpp: 154

--- a/contributing/parsers/cpp/GRAMMAR_ANALYSIS.md
+++ b/contributing/parsers/cpp/GRAMMAR_ANALYSIS.md
@@ -1,6 +1,6 @@
 # C++ Grammar Analysis
 
-*Generated: 2026-07-01 23:18:07 UTC*
+*Generated: 2026-07-14 21:19:18 UTC*
 
 ## Statistics
 - Total nodes in grammar JSON: 223

--- a/contributing/parsers/cpp/node_discovery.txt
+++ b/contributing/parsers/cpp/node_discovery.txt
@@ -1,5 +1,5 @@
 === C++ Language NODE MAPPING ===
-  Generated: 2026-07-01 23:18:07 UTC
+  Generated: 2026-07-14 21:19:18 UTC
   ABI Version: 14
   Node kind count: 154
 

--- a/contributing/parsers/cpp/node_discovery.txt
+++ b/contributing/parsers/cpp/node_discovery.txt
@@ -1,5 +1,4 @@
 === C++ Language NODE MAPPING ===
-  Generated: 2026-07-14 21:19:18 UTC
   ABI Version: 14
   Node kind count: 154
 

--- a/contributing/parsers/csharp/AUDIT_REPORT.md
+++ b/contributing/parsers/csharp/AUDIT_REPORT.md
@@ -1,6 +1,6 @@
 # C# Parser Coverage Report
 
-*Generated: 2026-07-01 23:18:07 UTC*
+*Generated: 2026-07-14 21:19:18 UTC*
 
 ## Summary
 - Key nodes: 31/32 (96%)

--- a/contributing/parsers/csharp/AUDIT_REPORT.md
+++ b/contributing/parsers/csharp/AUDIT_REPORT.md
@@ -1,7 +1,5 @@
 # C# Parser Coverage Report
 
-*Generated: 2026-07-14 21:19:18 UTC*
-
 ## Summary
 - Key nodes: 31/32 (96%)
 - Symbol kinds extracted: 9

--- a/contributing/parsers/csharp/GRAMMAR_ANALYSIS.md
+++ b/contributing/parsers/csharp/GRAMMAR_ANALYSIS.md
@@ -1,6 +1,6 @@
 # C# Grammar Analysis
 
-*Generated: 2026-07-01 23:18:07 UTC*
+*Generated: 2026-07-14 21:19:18 UTC*
 
 ## Statistics
 - Total nodes in grammar JSON: 220

--- a/contributing/parsers/csharp/GRAMMAR_ANALYSIS.md
+++ b/contributing/parsers/csharp/GRAMMAR_ANALYSIS.md
@@ -1,7 +1,5 @@
 # C# Grammar Analysis
 
-*Generated: 2026-07-14 21:19:18 UTC*
-
 ## Statistics
 - Total nodes in grammar JSON: 220
 - Nodes found in comprehensive.cs: 142

--- a/contributing/parsers/csharp/node_discovery.txt
+++ b/contributing/parsers/csharp/node_discovery.txt
@@ -1,5 +1,4 @@
 === C# Language NODE MAPPING ===
-  Generated: 2026-07-14 21:19:18 UTC
   ABI Version: 15
   Node kind count: 142
 

--- a/contributing/parsers/csharp/node_discovery.txt
+++ b/contributing/parsers/csharp/node_discovery.txt
@@ -1,5 +1,5 @@
 === C# Language NODE MAPPING ===
-  Generated: 2026-07-01 23:18:07 UTC
+  Generated: 2026-07-14 21:19:18 UTC
   ABI Version: 15
   Node kind count: 142
 

--- a/contributing/parsers/gdscript/AUDIT_REPORT.md
+++ b/contributing/parsers/gdscript/AUDIT_REPORT.md
@@ -1,7 +1,5 @@
 # GDScript Parser Symbol Extraction Coverage Report
 
-*Generated: 2026-07-14 21:19:18 UTC*
-
 ## Summary
 - Key nodes: 14/17 (82%)
 - Symbol kinds extracted: 7

--- a/contributing/parsers/gdscript/AUDIT_REPORT.md
+++ b/contributing/parsers/gdscript/AUDIT_REPORT.md
@@ -1,6 +1,6 @@
 # GDScript Parser Symbol Extraction Coverage Report
 
-*Generated: 2026-07-01 23:18:07 UTC*
+*Generated: 2026-07-14 21:19:18 UTC*
 
 ## Summary
 - Key nodes: 14/17 (82%)

--- a/contributing/parsers/gdscript/GRAMMAR_ANALYSIS.md
+++ b/contributing/parsers/gdscript/GRAMMAR_ANALYSIS.md
@@ -1,7 +1,5 @@
 # GDScript Grammar Analysis
 
-*Generated: 2026-07-14 21:19:18 UTC*
-
 ## Statistics
 - Total nodes in grammar JSON: 91
 - Nodes found in comprehensive.gd: 76

--- a/contributing/parsers/gdscript/GRAMMAR_ANALYSIS.md
+++ b/contributing/parsers/gdscript/GRAMMAR_ANALYSIS.md
@@ -1,6 +1,6 @@
 # GDScript Grammar Analysis
 
-*Generated: 2026-07-01 23:18:07 UTC*
+*Generated: 2026-07-14 21:19:18 UTC*
 
 ## Statistics
 - Total nodes in grammar JSON: 91

--- a/contributing/parsers/gdscript/node_discovery.txt
+++ b/contributing/parsers/gdscript/node_discovery.txt
@@ -1,5 +1,5 @@
 === GDScript Language NODE MAPPING ===
-  Generated: 2026-07-01 23:18:07 UTC
+  Generated: 2026-07-14 21:19:18 UTC
   ABI Version: 14
   Node kind count: 76
 

--- a/contributing/parsers/gdscript/node_discovery.txt
+++ b/contributing/parsers/gdscript/node_discovery.txt
@@ -1,5 +1,4 @@
 === GDScript Language NODE MAPPING ===
-  Generated: 2026-07-14 21:19:18 UTC
   ABI Version: 14
   Node kind count: 76
 

--- a/contributing/parsers/go/AUDIT_REPORT.md
+++ b/contributing/parsers/go/AUDIT_REPORT.md
@@ -1,7 +1,5 @@
 # Go Parser Symbol Extraction Coverage Report
 
-*Generated: 2026-07-14 21:19:18 UTC*
-
 ## Summary
 - Key nodes: 22/22 (100%)
 - Symbol kinds extracted: 9

--- a/contributing/parsers/go/AUDIT_REPORT.md
+++ b/contributing/parsers/go/AUDIT_REPORT.md
@@ -1,6 +1,6 @@
 # Go Parser Symbol Extraction Coverage Report
 
-*Generated: 2026-07-01 23:18:07 UTC*
+*Generated: 2026-07-14 21:19:18 UTC*
 
 ## Summary
 - Key nodes: 22/22 (100%)

--- a/contributing/parsers/go/GRAMMAR_ANALYSIS.md
+++ b/contributing/parsers/go/GRAMMAR_ANALYSIS.md
@@ -1,7 +1,5 @@
 # Go Grammar Analysis
 
-*Generated: 2026-07-14 21:19:18 UTC*
-
 ## Statistics
 - Total nodes in grammar JSON: 112
 - Nodes found in comprehensive.go: 115

--- a/contributing/parsers/go/GRAMMAR_ANALYSIS.md
+++ b/contributing/parsers/go/GRAMMAR_ANALYSIS.md
@@ -1,6 +1,6 @@
 # Go Grammar Analysis
 
-*Generated: 2026-07-01 23:18:07 UTC*
+*Generated: 2026-07-14 21:19:18 UTC*
 
 ## Statistics
 - Total nodes in grammar JSON: 112

--- a/contributing/parsers/go/node_discovery.txt
+++ b/contributing/parsers/go/node_discovery.txt
@@ -1,5 +1,4 @@
 === Go Language NODE MAPPING ===
-  Generated: 2026-07-14 21:19:18 UTC
   ABI Version: 15
   Node kind count: 115
 

--- a/contributing/parsers/go/node_discovery.txt
+++ b/contributing/parsers/go/node_discovery.txt
@@ -1,5 +1,5 @@
 === Go Language NODE MAPPING ===
-  Generated: 2026-07-01 23:18:07 UTC
+  Generated: 2026-07-14 21:19:18 UTC
   ABI Version: 15
   Node kind count: 115
 

--- a/contributing/parsers/java/AUDIT_REPORT.md
+++ b/contributing/parsers/java/AUDIT_REPORT.md
@@ -1,7 +1,5 @@
 # Java Parser Symbol Extraction Coverage Report
 
-*Generated: 2026-07-14 21:19:18 UTC*
-
 ## Summary
 - Key nodes: 13/13 (100%)
 - Symbol kinds extracted: 5

--- a/contributing/parsers/java/AUDIT_REPORT.md
+++ b/contributing/parsers/java/AUDIT_REPORT.md
@@ -1,6 +1,6 @@
 # Java Parser Symbol Extraction Coverage Report
 
-*Generated: 2026-07-01 23:18:07 UTC*
+*Generated: 2026-07-14 21:19:18 UTC*
 
 ## Summary
 - Key nodes: 13/13 (100%)

--- a/contributing/parsers/java/GRAMMAR_ANALYSIS.md
+++ b/contributing/parsers/java/GRAMMAR_ANALYSIS.md
@@ -1,7 +1,5 @@
 # Java Grammar Analysis
 
-*Generated: 2026-07-14 21:19:18 UTC*
-
 ## Statistics
 - Total nodes in grammar JSON: 151
 - Nodes found in comprehensive.java: 92

--- a/contributing/parsers/java/GRAMMAR_ANALYSIS.md
+++ b/contributing/parsers/java/GRAMMAR_ANALYSIS.md
@@ -1,6 +1,6 @@
 # Java Grammar Analysis
 
-*Generated: 2026-07-01 23:18:07 UTC*
+*Generated: 2026-07-14 21:19:18 UTC*
 
 ## Statistics
 - Total nodes in grammar JSON: 151

--- a/contributing/parsers/java/node_discovery.txt
+++ b/contributing/parsers/java/node_discovery.txt
@@ -1,5 +1,5 @@
 === Java Language NODE MAPPING ===
-  Generated: 2026-07-01 23:18:07 UTC
+  Generated: 2026-07-14 21:19:18 UTC
   ABI Version: 14
   Node kind count: 92
 

--- a/contributing/parsers/java/node_discovery.txt
+++ b/contributing/parsers/java/node_discovery.txt
@@ -1,5 +1,4 @@
 === Java Language NODE MAPPING ===
-  Generated: 2026-07-14 21:19:18 UTC
   ABI Version: 14
   Node kind count: 92
 

--- a/contributing/parsers/javascript/AUDIT_REPORT.md
+++ b/contributing/parsers/javascript/AUDIT_REPORT.md
@@ -1,6 +1,6 @@
 # JavaScript Parser Coverage Report
 
-*Generated: 2026-07-01 23:18:07 UTC*
+*Generated: 2026-07-14 21:19:18 UTC*
 
 ## Summary
 - Key nodes: 16/16 (100%)

--- a/contributing/parsers/javascript/AUDIT_REPORT.md
+++ b/contributing/parsers/javascript/AUDIT_REPORT.md
@@ -1,7 +1,5 @@
 # JavaScript Parser Coverage Report
 
-*Generated: 2026-07-14 21:19:18 UTC*
-
 ## Summary
 - Key nodes: 16/16 (100%)
 - Symbol kinds extracted: 6

--- a/contributing/parsers/javascript/GRAMMAR_ANALYSIS.md
+++ b/contributing/parsers/javascript/GRAMMAR_ANALYSIS.md
@@ -1,7 +1,5 @@
 # JavaScript Grammar Analysis
 
-*Generated: 2026-07-14 21:19:18 UTC*
-
 ## Statistics
 - Total nodes in grammar JSON: 119
 - Nodes found in comprehensive.js: 142

--- a/contributing/parsers/javascript/GRAMMAR_ANALYSIS.md
+++ b/contributing/parsers/javascript/GRAMMAR_ANALYSIS.md
@@ -1,6 +1,6 @@
 # JavaScript Grammar Analysis
 
-*Generated: 2026-07-01 23:18:07 UTC*
+*Generated: 2026-07-14 21:19:18 UTC*
 
 ## Statistics
 - Total nodes in grammar JSON: 119

--- a/contributing/parsers/javascript/node_discovery.txt
+++ b/contributing/parsers/javascript/node_discovery.txt
@@ -1,5 +1,4 @@
 === JavaScript Language NODE MAPPING ===
-  Generated: 2026-07-14 21:19:18 UTC
   ABI Version: 15
   Node kind count: 142
 

--- a/contributing/parsers/javascript/node_discovery.txt
+++ b/contributing/parsers/javascript/node_discovery.txt
@@ -1,5 +1,5 @@
 === JavaScript Language NODE MAPPING ===
-  Generated: 2026-07-01 23:18:07 UTC
+  Generated: 2026-07-14 21:19:18 UTC
   ABI Version: 15
   Node kind count: 142
 

--- a/contributing/parsers/kotlin/AUDIT_REPORT.md
+++ b/contributing/parsers/kotlin/AUDIT_REPORT.md
@@ -1,6 +1,6 @@
 # Kotlin Parser Symbol Extraction Coverage Report
 
-*Generated: 2026-07-01 23:18:07 UTC*
+*Generated: 2026-07-14 21:19:18 UTC*
 
 ## Summary
 - Key nodes: 17/17 (100%)

--- a/contributing/parsers/kotlin/AUDIT_REPORT.md
+++ b/contributing/parsers/kotlin/AUDIT_REPORT.md
@@ -1,7 +1,5 @@
 # Kotlin Parser Symbol Extraction Coverage Report
 
-*Generated: 2026-07-14 21:19:18 UTC*
-
 ## Summary
 - Key nodes: 17/17 (100%)
 - Symbol kinds extracted: 8

--- a/contributing/parsers/kotlin/GRAMMAR_ANALYSIS.md
+++ b/contributing/parsers/kotlin/GRAMMAR_ANALYSIS.md
@@ -1,6 +1,6 @@
 # Kotlin Grammar Analysis
 
-*Generated: 2026-07-01 23:18:07 UTC*
+*Generated: 2026-07-14 21:19:18 UTC*
 
 ## Statistics
 - Total nodes in grammar JSON: 136

--- a/contributing/parsers/kotlin/GRAMMAR_ANALYSIS.md
+++ b/contributing/parsers/kotlin/GRAMMAR_ANALYSIS.md
@@ -1,7 +1,5 @@
 # Kotlin Grammar Analysis
 
-*Generated: 2026-07-14 21:19:18 UTC*
-
 ## Statistics
 - Total nodes in grammar JSON: 136
 - Nodes found in comprehensive.kt: 152

--- a/contributing/parsers/kotlin/node_discovery.txt
+++ b/contributing/parsers/kotlin/node_discovery.txt
@@ -1,5 +1,5 @@
 === Kotlin Language NODE MAPPING ===
-  Generated: 2026-07-01 23:18:07 UTC
+  Generated: 2026-07-14 21:19:18 UTC
   ABI Version: 14
   Node kind count: 152
 

--- a/contributing/parsers/kotlin/node_discovery.txt
+++ b/contributing/parsers/kotlin/node_discovery.txt
@@ -1,5 +1,4 @@
 === Kotlin Language NODE MAPPING ===
-  Generated: 2026-07-14 21:19:18 UTC
   ABI Version: 14
   Node kind count: 152
 

--- a/contributing/parsers/lua/AUDIT_REPORT.md
+++ b/contributing/parsers/lua/AUDIT_REPORT.md
@@ -1,7 +1,5 @@
 # Lua Parser Symbol Extraction Coverage Report
 
-*Generated: 2026-07-14 21:19:18 UTC*
-
 ## Summary
 - Key nodes: 21/21 (100%)
 - Symbol kinds extracted: 6

--- a/contributing/parsers/lua/AUDIT_REPORT.md
+++ b/contributing/parsers/lua/AUDIT_REPORT.md
@@ -1,6 +1,6 @@
 # Lua Parser Symbol Extraction Coverage Report
 
-*Generated: 2026-07-01 23:18:07 UTC*
+*Generated: 2026-07-14 21:19:18 UTC*
 
 ## Summary
 - Key nodes: 21/21 (100%)

--- a/contributing/parsers/lua/GRAMMAR_ANALYSIS.md
+++ b/contributing/parsers/lua/GRAMMAR_ANALYSIS.md
@@ -1,6 +1,6 @@
 # Lua Grammar Analysis
 
-*Generated: 2026-07-01 23:18:07 UTC*
+*Generated: 2026-07-14 21:19:18 UTC*
 
 ## Statistics
 - Total nodes in grammar JSON: 0

--- a/contributing/parsers/lua/GRAMMAR_ANALYSIS.md
+++ b/contributing/parsers/lua/GRAMMAR_ANALYSIS.md
@@ -1,7 +1,5 @@
 # Lua Grammar Analysis
 
-*Generated: 2026-07-14 21:19:18 UTC*
-
 ## Statistics
 - Total nodes in grammar JSON: 0
 - Nodes found in comprehensive.lua: 75

--- a/contributing/parsers/lua/node_discovery.txt
+++ b/contributing/parsers/lua/node_discovery.txt
@@ -1,5 +1,5 @@
 === Lua Language NODE MAPPING ===
-  Generated: 2026-07-01 23:18:07 UTC
+  Generated: 2026-07-14 21:19:18 UTC
   ABI Version: 15
   Node kind count: 75
 

--- a/contributing/parsers/lua/node_discovery.txt
+++ b/contributing/parsers/lua/node_discovery.txt
@@ -1,5 +1,4 @@
 === Lua Language NODE MAPPING ===
-  Generated: 2026-07-14 21:19:18 UTC
   ABI Version: 15
   Node kind count: 75
 

--- a/contributing/parsers/php/AUDIT_REPORT.md
+++ b/contributing/parsers/php/AUDIT_REPORT.md
@@ -1,7 +1,5 @@
 # PHP Parser Coverage Report
 
-*Generated: 2026-07-14 21:19:18 UTC*
-
 ## Summary
 - Key nodes: 21/21 (100%)
 - Symbol kinds extracted: 8

--- a/contributing/parsers/php/AUDIT_REPORT.md
+++ b/contributing/parsers/php/AUDIT_REPORT.md
@@ -1,6 +1,6 @@
 # PHP Parser Coverage Report
 
-*Generated: 2026-07-01 23:18:07 UTC*
+*Generated: 2026-07-14 21:19:18 UTC*
 
 ## Summary
 - Key nodes: 21/21 (100%)

--- a/contributing/parsers/php/GRAMMAR_ANALYSIS.md
+++ b/contributing/parsers/php/GRAMMAR_ANALYSIS.md
@@ -1,7 +1,5 @@
 # PHP Grammar Analysis
 
-*Generated: 2026-07-14 21:19:18 UTC*
-
 ## Statistics
 - Total nodes in grammar JSON: 161
 - Nodes found in comprehensive.php: 177

--- a/contributing/parsers/php/GRAMMAR_ANALYSIS.md
+++ b/contributing/parsers/php/GRAMMAR_ANALYSIS.md
@@ -1,6 +1,6 @@
 # PHP Grammar Analysis
 
-*Generated: 2026-07-01 23:18:07 UTC*
+*Generated: 2026-07-14 21:19:18 UTC*
 
 ## Statistics
 - Total nodes in grammar JSON: 161

--- a/contributing/parsers/php/node_discovery.txt
+++ b/contributing/parsers/php/node_discovery.txt
@@ -1,5 +1,5 @@
 === PHP Language NODE MAPPING ===
-  Generated: 2026-07-01 23:18:07 UTC
+  Generated: 2026-07-14 21:19:18 UTC
   ABI Version: 15
   Node kind count: 177
 

--- a/contributing/parsers/php/node_discovery.txt
+++ b/contributing/parsers/php/node_discovery.txt
@@ -1,5 +1,4 @@
 === PHP Language NODE MAPPING ===
-  Generated: 2026-07-14 21:19:18 UTC
   ABI Version: 15
   Node kind count: 177
 

--- a/contributing/parsers/python/AUDIT_REPORT.md
+++ b/contributing/parsers/python/AUDIT_REPORT.md
@@ -1,6 +1,6 @@
 # Python Parser Symbol Extraction Coverage Report
 
-*Generated: 2026-07-01 23:18:07 UTC*
+*Generated: 2026-07-14 21:19:18 UTC*
 
 ## Summary
 - Key nodes: 23/23 (100%)

--- a/contributing/parsers/python/AUDIT_REPORT.md
+++ b/contributing/parsers/python/AUDIT_REPORT.md
@@ -1,7 +1,5 @@
 # Python Parser Symbol Extraction Coverage Report
 
-*Generated: 2026-07-14 21:19:18 UTC*
-
 ## Summary
 - Key nodes: 23/23 (100%)
 - Symbol kinds extracted: 6

--- a/contributing/parsers/python/GRAMMAR_ANALYSIS.md
+++ b/contributing/parsers/python/GRAMMAR_ANALYSIS.md
@@ -1,6 +1,6 @@
 # Python Grammar Analysis
 
-*Generated: 2026-07-01 23:18:07 UTC*
+*Generated: 2026-07-14 21:19:18 UTC*
 
 ## Statistics
 - Total nodes in grammar JSON: 129

--- a/contributing/parsers/python/GRAMMAR_ANALYSIS.md
+++ b/contributing/parsers/python/GRAMMAR_ANALYSIS.md
@@ -1,7 +1,5 @@
 # Python Grammar Analysis
 
-*Generated: 2026-07-14 21:19:18 UTC*
-
 ## Statistics
 - Total nodes in grammar JSON: 129
 - Nodes found in comprehensive.py: 136

--- a/contributing/parsers/python/node_discovery.txt
+++ b/contributing/parsers/python/node_discovery.txt
@@ -1,5 +1,4 @@
 === Python Language NODE MAPPING ===
-  Generated: 2026-07-14 21:19:18 UTC
   ABI Version: 15
   Node kind count: 136
 

--- a/contributing/parsers/python/node_discovery.txt
+++ b/contributing/parsers/python/node_discovery.txt
@@ -1,5 +1,5 @@
 === Python Language NODE MAPPING ===
-  Generated: 2026-07-01 23:18:07 UTC
+  Generated: 2026-07-14 21:19:18 UTC
   ABI Version: 15
   Node kind count: 136
 

--- a/contributing/parsers/rust/AUDIT_REPORT.md
+++ b/contributing/parsers/rust/AUDIT_REPORT.md
@@ -1,7 +1,5 @@
 # Rust Parser Coverage Report
 
-*Generated: 2026-07-14 21:19:18 UTC*
-
 ## Summary
 - Key nodes: 23/23 (100%)
 - Symbol kinds extracted: 10

--- a/contributing/parsers/rust/AUDIT_REPORT.md
+++ b/contributing/parsers/rust/AUDIT_REPORT.md
@@ -1,6 +1,6 @@
 # Rust Parser Coverage Report
 
-*Generated: 2026-07-01 23:18:07 UTC*
+*Generated: 2026-07-14 21:19:18 UTC*
 
 ## Summary
 - Key nodes: 23/23 (100%)

--- a/contributing/parsers/rust/GRAMMAR_ANALYSIS.md
+++ b/contributing/parsers/rust/GRAMMAR_ANALYSIS.md
@@ -1,7 +1,5 @@
 # Rust Grammar Analysis
 
-*Generated: 2026-07-14 21:19:18 UTC*
-
 ## Statistics
 - Total nodes in grammar JSON: 169
 - Nodes found in comprehensive.rs: 147

--- a/contributing/parsers/rust/GRAMMAR_ANALYSIS.md
+++ b/contributing/parsers/rust/GRAMMAR_ANALYSIS.md
@@ -1,6 +1,6 @@
 # Rust Grammar Analysis
 
-*Generated: 2026-07-01 23:18:07 UTC*
+*Generated: 2026-07-14 21:19:18 UTC*
 
 ## Statistics
 - Total nodes in grammar JSON: 169

--- a/contributing/parsers/rust/node_discovery.txt
+++ b/contributing/parsers/rust/node_discovery.txt
@@ -1,5 +1,4 @@
 === Rust Language NODE MAPPING ===
-  Generated: 2026-07-14 21:19:18 UTC
   ABI Version: 15
   Node kind count: 147
 

--- a/contributing/parsers/rust/node_discovery.txt
+++ b/contributing/parsers/rust/node_discovery.txt
@@ -1,5 +1,5 @@
 === Rust Language NODE MAPPING ===
-  Generated: 2026-07-01 23:18:07 UTC
+  Generated: 2026-07-14 21:19:18 UTC
   ABI Version: 15
   Node kind count: 147
 

--- a/contributing/parsers/typescript/AUDIT_REPORT.md
+++ b/contributing/parsers/typescript/AUDIT_REPORT.md
@@ -1,7 +1,5 @@
 # TypeScript Parser Coverage Report
 
-*Generated: 2026-07-14 21:19:18 UTC*
-
 ## Summary
 - Key nodes: 28/28 (100%)
 - Symbol kinds extracted: 9

--- a/contributing/parsers/typescript/AUDIT_REPORT.md
+++ b/contributing/parsers/typescript/AUDIT_REPORT.md
@@ -1,6 +1,6 @@
 # TypeScript Parser Coverage Report
 
-*Generated: 2026-07-01 23:18:07 UTC*
+*Generated: 2026-07-14 21:19:18 UTC*
 
 ## Summary
 - Key nodes: 28/28 (100%)

--- a/contributing/parsers/typescript/GRAMMAR_ANALYSIS.md
+++ b/contributing/parsers/typescript/GRAMMAR_ANALYSIS.md
@@ -1,6 +1,6 @@
 # TypeScript Grammar Analysis
 
-*Generated: 2026-07-01 23:18:07 UTC*
+*Generated: 2026-07-14 21:19:18 UTC*
 
 ## Statistics
 - Total nodes in grammar JSON: 183

--- a/contributing/parsers/typescript/GRAMMAR_ANALYSIS.md
+++ b/contributing/parsers/typescript/GRAMMAR_ANALYSIS.md
@@ -1,7 +1,5 @@
 # TypeScript Grammar Analysis
 
-*Generated: 2026-07-14 21:19:18 UTC*
-
 ## Statistics
 - Total nodes in grammar JSON: 183
 - Nodes found in comprehensive.ts: 203

--- a/contributing/parsers/typescript/node_discovery.txt
+++ b/contributing/parsers/typescript/node_discovery.txt
@@ -1,5 +1,4 @@
 === TypeScript Language NODE MAPPING ===
-  Generated: 2026-07-14 21:19:18 UTC
   ABI Version: 14
   Node kind count: 198
 

--- a/contributing/parsers/typescript/node_discovery.txt
+++ b/contributing/parsers/typescript/node_discovery.txt
@@ -1,5 +1,5 @@
 === TypeScript Language NODE MAPPING ===
-  Generated: 2026-07-01 23:18:07 UTC
+  Generated: 2026-07-14 21:19:18 UTC
   ABI Version: 14
   Node kind count: 198
 

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -195,7 +195,7 @@ pub enum Commands {
     #[command(
         about = "Start MCP server",
         long_about = "Start MCP server with optional HTTP/HTTPS modes.",
-        after_help = "Examples:\n  codanna serve\n  codanna serve --http --watch\n  codanna serve --https --watch\n  codanna serve --http --bind 0.0.0.0:3000\n\nModes:\n  Default: stdio\n  --http: HTTP with OAuth\n  --https: HTTPS with TLS"
+        after_help = "Examples:\n  codanna serve\n  codanna serve --http --watch\n  codanna serve --https --watch\n  codanna serve --http --bind 0.0.0.0:3000\n  codanna serve --proxy\n\nModes:\n  Default: stdio\n  --http: HTTP with OAuth\n  --https: HTTPS with TLS\n  --proxy: stdio-facing proxy that discovers/spawns a backing HTTP server"
     )]
     Serve {
         /// Watch index file for changes and auto-reload
@@ -221,6 +221,14 @@ pub enum Commands {
             help = "Run as HTTPS server with TLS support"
         )]
         https: bool,
+
+        /// Run as a stdio-facing proxy that delegates to a discovered/spawned HTTP server
+        #[arg(
+            long,
+            conflicts_with_all = ["http", "https"],
+            help = "Speak stdio to the client while delegating to a backing HTTP MCP server"
+        )]
+        proxy: bool,
 
         /// Bind address for HTTP/HTTPS server
         #[arg(

--- a/src/cli/commands/serve.rs
+++ b/src/cli/commands/serve.rs
@@ -1,111 +1,11 @@
 //! Serve command - MCP server modes (stdio, HTTP, HTTPS).
 
-use std::fs::OpenOptions;
-use std::io::Write;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use crate::config::Settings;
 use crate::indexing::facade::IndexFacade;
-
-/// PID lockfile guard for stdio MCP servers. Prevents two concurrent
-/// `codanna serve` (stdio) processes from racing the tantivy writer on the
-/// same `.codanna/index/`. Removed automatically on drop. HTTP/HTTPS modes
-/// get exclusion via port binding and do not use this lock.
-struct ServeLockGuard {
-    path: PathBuf,
-}
-
-#[derive(Debug)]
-enum ServeLockError {
-    AlreadyRunning { pid: u32, lock_path: PathBuf },
-    Io(std::io::Error),
-}
-
-impl ServeLockGuard {
-    /// `create_new`-first acquire: the lockfile is only ever removed after
-    /// `create_new` has failed with `AlreadyExists` AND the recorded PID is
-    /// verified dead. An unconditional pre-remove would delete a racing
-    /// process's live lock and let two servers share one tantivy index.
-    fn acquire(index_path: &Path) -> Result<Self, ServeLockError> {
-        let lock_path = index_path.join("serve.lock");
-
-        if let Some(parent) = lock_path.parent() {
-            std::fs::create_dir_all(parent).map_err(ServeLockError::Io)?;
-        }
-
-        for _ in 0..3 {
-            match OpenOptions::new()
-                .write(true)
-                .create_new(true)
-                .open(&lock_path)
-            {
-                Ok(mut f) => {
-                    f.write_all(std::process::id().to_string().as_bytes())
-                        .map_err(ServeLockError::Io)?;
-                    return Ok(Self { path: lock_path });
-                }
-                Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
-                    match read_lock_pid(&lock_path) {
-                        Some(pid) if pid_is_alive(pid) => {
-                            return Err(ServeLockError::AlreadyRunning { pid, lock_path });
-                        }
-                        Some(_) => {
-                            // Recorded process is dead: reclaim and retry.
-                            let _ = std::fs::remove_file(&lock_path);
-                        }
-                        None => {
-                            // No parseable PID. A racing process may have
-                            // created the lock but not written its PID yet;
-                            // re-read after a grace window before treating
-                            // the file as a dead leftover (SIGKILL between
-                            // create and write leaves an empty lock that
-                            // must self-heal).
-                            std::thread::sleep(std::time::Duration::from_millis(50));
-                            match read_lock_pid(&lock_path) {
-                                Some(pid) if pid_is_alive(pid) => {
-                                    return Err(ServeLockError::AlreadyRunning { pid, lock_path });
-                                }
-                                _ => {
-                                    let _ = std::fs::remove_file(&lock_path);
-                                }
-                            }
-                        }
-                    }
-                }
-                Err(e) => return Err(ServeLockError::Io(e)),
-            }
-        }
-
-        // Retries exhausted: another process keeps winning the create race.
-        let pid = read_lock_pid(&lock_path).unwrap_or(0);
-        Err(ServeLockError::AlreadyRunning { pid, lock_path })
-    }
-}
-
-fn read_lock_pid(lock_path: &Path) -> Option<u32> {
-    std::fs::read_to_string(lock_path)
-        .ok()
-        .and_then(|s| s.trim().parse::<u32>().ok())
-}
-
-impl Drop for ServeLockGuard {
-    fn drop(&mut self) {
-        let _ = std::fs::remove_file(&self.path);
-    }
-}
-
-fn pid_is_alive(pid: u32) -> bool {
-    use sysinfo::{Pid, ProcessRefreshKind, ProcessesToUpdate, System};
-    let mut sys = System::new();
-    let pid = Pid::from_u32(pid);
-    sys.refresh_processes_specifics(
-        ProcessesToUpdate::Some(&[pid]),
-        true,
-        ProcessRefreshKind::nothing(),
-    );
-    sys.process(pid).is_some()
-}
+use crate::serve_discovery::{PidLockError, PidLockGuard};
 
 /// Arguments for the serve command.
 pub struct ServeArgs {
@@ -113,15 +13,47 @@ pub struct ServeArgs {
     pub watch_interval: u64,
     pub http: bool,
     pub https: bool,
+    pub proxy: bool,
     pub bind: String,
 }
 
+/// Resolve which server transport `codanna serve` should start.
+///
+/// Precedence mirrors `main.rs`'s `is_proxy_serve` so the pre-dispatch
+/// resource predicates and the actual server startup never disagree about
+/// which mode is in effect:
+/// 1. CLI `--https` (highest precedence)
+/// 2. CLI `--http`
+/// 3. CLI `--proxy`, OR `config.server.mode == "proxy"` when no CLI transport
+///    flag was given (bare `codanna serve` can default to proxy via
+///    `settings.toml`)
+/// 4. `config.server.mode == "http"`
+/// 5. stdio (default)
+fn resolve_server_mode(https: bool, http: bool, proxy: bool, config_mode: &str) -> &'static str {
+    if https {
+        "https"
+    } else if http {
+        "http"
+    } else if proxy || config_mode == "proxy" {
+        "proxy"
+    } else if config_mode == "http" {
+        "http"
+    } else {
+        "stdio"
+    }
+}
+
 /// Run the serve command.
+///
+/// `facade` is `None` exactly when proxy mode is selected: `main.rs` computes
+/// the effective mode ahead of index loading (§4.5) and skips constructing an
+/// `IndexFacade` entirely for proxy, since the proxy process holds no index
+/// state of its own -- it only relays to a backing HTTP server's facade.
 pub async fn run(
     args: ServeArgs,
     config: Settings,
     settings: Arc<Settings>,
-    facade: IndexFacade,
+    facade: Option<IndexFacade>,
     index_path: PathBuf,
 ) {
     let ServeArgs {
@@ -129,20 +61,11 @@ pub async fn run(
         watch_interval,
         http,
         https,
+        proxy,
         bind,
     } = args;
 
-    // Determine server mode:
-    // 1. CLI --https flag takes highest precedence
-    // 2. CLI --http flag takes second precedence
-    // 3. Otherwise, check config.server.mode
-    let server_mode = if https {
-        "https"
-    } else if http || config.server.mode == "http" {
-        "http"
-    } else {
-        "stdio"
-    };
+    let server_mode = resolve_server_mode(https, http, proxy, &config.server.mode);
 
     // Use bind address from CLI if provided, otherwise from config
     // For HTTPS, default to port 8443 if using default bind
@@ -172,11 +95,14 @@ pub async fn run(
         "http" => {
             run_http_server(config, watch, bind_address).await;
         }
+        "proxy" => {
+            run_proxy_server(config).await;
+        }
         _ => {
             run_stdio_server(
                 config,
                 settings,
-                facade,
+                facade.expect("stdio serve requires an already-loaded IndexFacade"),
                 index_path,
                 watch,
                 actual_watch_interval,
@@ -215,6 +141,18 @@ async fn run_https_server(config: &Settings, watch: bool, bind_address: String) 
     }
 }
 
+async fn run_proxy_server(config: Settings) {
+    // Proxy mode - stdio-facing delegate that discovers/spawns a backing
+    // `codanna serve --http` and relays MCP traffic to it. No IndexFacade is
+    // constructed in this process (§4.5).
+    eprintln!("Starting MCP server in proxy mode (stdio <-> HTTP delegate)");
+
+    if let Err(e) = crate::mcp::proxy::serve_proxy(config).await {
+        eprintln!("Proxy server error: {e}");
+        std::process::exit(1);
+    }
+}
+
 async fn run_http_server(config: Settings, watch: bool, bind_address: String) {
     // HTTP mode - persistent server with event-driven file watching
     eprintln!("Starting MCP server in HTTP mode");
@@ -246,9 +184,9 @@ async fn run_stdio_server(
     // function scope so the guard removes the lockfile on return / unwind.
     // The process::exit arms below must drop it explicitly: exit skips
     // destructors and would leave the lockfile behind.
-    let serve_lock = match ServeLockGuard::acquire(&index_path) {
+    let serve_lock = match PidLockGuard::acquire(&index_path.join("serve.lock")) {
         Ok(guard) => guard,
-        Err(ServeLockError::AlreadyRunning { pid, lock_path }) => {
+        Err(PidLockError::Held { pid, lock_path }) => {
             eprintln!(
                 "Another codanna serve is already running for this index (PID {pid}, lock at {}).",
                 lock_path.display()
@@ -265,7 +203,7 @@ async fn run_stdio_server(
             );
             std::process::exit(1);
         }
-        Err(ServeLockError::Io(e)) => {
+        Err(PidLockError::Io(e)) => {
             eprintln!(
                 "Failed to acquire serve lock under {}: {e}",
                 index_path.display()
@@ -442,71 +380,50 @@ pub async fn run_mcp_test(
 }
 
 #[cfg(test)]
-mod serve_lock_tests {
-    use super::*;
-    use tempfile::TempDir;
+mod server_mode_selection_tests {
+    use super::resolve_server_mode;
+
+    // These tests exercise `resolve_server_mode` in isolation: it is a pure
+    // function of (https, http, proxy, config_mode) -> &'static str with no
+    // I/O, so precedence can be asserted hermetically without spawning any
+    // process or binding any port.
+    //
+    // The stdio<->HTTP delegating pump in `mcp::proxy` is intentionally NOT
+    // unit tested here: exercising it for real requires a live backing HTTP
+    // MCP server (a spawned child process) and a connected stdio client on
+    // the other end, which is an integration/manual validation concern, not
+    // a hermetic unit test.
 
     #[test]
-    fn acquire_writes_pid_and_drop_removes_lock() {
-        let dir = TempDir::new().unwrap();
-        let lock_path = dir.path().join("serve.lock");
-
-        {
-            let _guard = ServeLockGuard::acquire(dir.path()).expect("first acquire");
-            let contents = std::fs::read_to_string(&lock_path).unwrap();
-            assert_eq!(contents.trim(), std::process::id().to_string());
-        }
-
-        assert!(
-            !lock_path.exists(),
-            "lockfile should be removed when guard drops"
-        );
+    fn cli_proxy_flag_selects_proxy() {
+        assert_eq!(resolve_server_mode(false, false, true, "stdio"), "proxy");
     }
 
     #[test]
-    fn second_acquire_blocks_when_first_is_alive() {
-        let dir = TempDir::new().unwrap();
-        let _first = ServeLockGuard::acquire(dir.path()).expect("first acquire");
-
-        match ServeLockGuard::acquire(dir.path()) {
-            Err(ServeLockError::AlreadyRunning { pid, .. }) => {
-                assert_eq!(pid, std::process::id());
-            }
-            Ok(_) => panic!("second acquire should have failed"),
-            Err(other) => panic!("unexpected error: {other:?}"),
-        }
+    fn config_mode_proxy_selects_proxy_with_bare_serve() {
+        // Bare `codanna serve` (no CLI transport flags) must be able to
+        // default to proxy via settings.toml `server.mode = "proxy"`.
+        assert_eq!(resolve_server_mode(false, false, false, "proxy"), "proxy");
     }
 
     #[test]
-    fn unparseable_lock_is_reclaimed_after_grace_window() {
-        let dir = TempDir::new().unwrap();
-        let lock_path = dir.path().join("serve.lock");
-
-        // SIGKILL between create and PID write leaves an empty lock; it must
-        // self-heal instead of blocking serve forever.
-        std::fs::write(&lock_path, "").unwrap();
-
-        let guard = ServeLockGuard::acquire(dir.path()).expect("empty lock should be reclaimed");
-        let contents = std::fs::read_to_string(&lock_path).unwrap();
-        assert_eq!(contents.trim(), std::process::id().to_string());
-        drop(guard);
-        assert!(!lock_path.exists());
+    fn cli_http_flag_wins_over_config_mode_proxy() {
+        assert_eq!(resolve_server_mode(false, true, false, "proxy"), "http");
     }
 
     #[test]
-    fn stale_lock_with_dead_pid_is_overwritten() {
-        let dir = TempDir::new().unwrap();
-        let lock_path = dir.path().join("serve.lock");
+    fn cli_https_flag_wins_over_everything() {
+        assert_eq!(resolve_server_mode(true, false, false, "proxy"), "https");
+        assert_eq!(resolve_server_mode(true, false, true, "http"), "https");
+    }
 
-        // PID 0 never refers to a normal process on Unix; sysinfo also reports
-        // it as absent. Use it as a synthetic stale entry.
-        std::fs::write(&lock_path, "0").unwrap();
-        assert!(!pid_is_alive(0), "PID 0 must read as dead for this test");
+    #[test]
+    fn config_mode_http_selects_http_without_cli_flags() {
+        assert_eq!(resolve_server_mode(false, false, false, "http"), "http");
+    }
 
-        let guard = ServeLockGuard::acquire(dir.path()).expect("stale lock should be reclaimed");
-        let contents = std::fs::read_to_string(&lock_path).unwrap();
-        assert_eq!(contents.trim(), std::process::id().to_string());
-        drop(guard);
-        assert!(!lock_path.exists());
+    #[test]
+    fn default_is_stdio() {
+        assert_eq!(resolve_server_mode(false, false, false, "stdio"), "stdio");
     }
 }

--- a/src/config/defaults.rs
+++ b/src/config/defaults.rs
@@ -71,6 +71,18 @@ pub(super) fn default_bind_address() -> String {
 pub(super) fn default_watch_interval() -> u64 {
     5
 }
+pub(super) fn default_auto_spawn() -> bool {
+    true
+}
+pub(super) fn default_idle_timeout_secs() -> u64 {
+    0
+}
+pub(super) fn default_spawn_timeout_ms() -> u64 {
+    8000
+}
+pub(super) fn default_health_poll_ms() -> u64 {
+    100
+}
 
 pub(super) fn default_guidance_templates() -> IndexMap<String, GuidanceTemplate> {
     let mut templates = IndexMap::new();

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -258,6 +258,22 @@ pub struct ServerConfig {
     /// Watch interval for stdio mode (seconds)
     #[serde(default = "default_watch_interval")]
     pub watch_interval: u64,
+
+    /// Whether the proxy mode auto-spawns a backing server process
+    #[serde(default = "default_auto_spawn")]
+    pub auto_spawn: bool,
+
+    /// Idle timeout for the auto-spawned server, in seconds (0 = never)
+    #[serde(default = "default_idle_timeout_secs")]
+    pub idle_timeout_secs: u64,
+
+    /// Timeout for spawning the backing server, in milliseconds
+    #[serde(default = "default_spawn_timeout_ms")]
+    pub spawn_timeout_ms: u64,
+
+    /// Poll interval while waiting for the backing server to become healthy, in milliseconds
+    #[serde(default = "default_health_poll_ms")]
+    pub health_poll_ms: u64,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
@@ -406,6 +422,10 @@ impl Default for ServerConfig {
             mode: default_server_mode(),
             bind: default_bind_address(),
             watch_interval: default_watch_interval(),
+            auto_spawn: default_auto_spawn(),
+            idle_timeout_secs: default_idle_timeout_secs(),
+            spawn_timeout_ms: default_spawn_timeout_ms(),
+            health_poll_ms: default_health_poll_ms(),
         }
     }
 }
@@ -640,6 +660,38 @@ enabled = false
         assert_eq!(settings.indexing.ignore_patterns.len(), 1);
         assert_eq!(settings.mcp.max_context_size, 200000);
         assert!(!settings.languages["rust"].enabled);
+    }
+
+    #[test]
+    fn test_server_config_minimal_toml_uses_proxy_defaults() {
+        let toml_content = r#"
+mode = "stdio"
+"#;
+        let server: ServerConfig = toml::from_str(toml_content).unwrap();
+        assert_eq!(server.mode, "stdio");
+        assert_eq!(server.bind, default_bind_address());
+        assert_eq!(server.watch_interval, default_watch_interval());
+        assert!(server.auto_spawn);
+        assert_eq!(server.idle_timeout_secs, 0);
+        assert_eq!(server.spawn_timeout_ms, 8000);
+        assert_eq!(server.health_poll_ms, 100);
+    }
+
+    #[test]
+    fn test_server_config_proxy_mode_round_trips() {
+        let toml_content = r#"
+mode = "proxy"
+"#;
+        let server: ServerConfig = toml::from_str(toml_content).unwrap();
+        assert_eq!(server.mode, "proxy");
+
+        let serialized = toml::to_string(&server).unwrap();
+        let round_tripped: ServerConfig = toml::from_str(&serialized).unwrap();
+        assert_eq!(round_tripped.mode, "proxy");
+        assert_eq!(round_tripped.auto_spawn, server.auto_spawn);
+        assert_eq!(round_tripped.idle_timeout_secs, server.idle_timeout_secs);
+        assert_eq!(round_tripped.spawn_timeout_ms, server.spawn_timeout_ms);
+        assert_eq!(round_tripped.health_poll_ms, server.health_poll_ms);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,8 @@ pub mod project_resolver;
 pub mod relationship;
 pub mod retrieve;
 pub mod semantic;
+pub mod serve_discovery;
+pub mod serve_tls;
 pub mod storage;
 pub mod symbol;
 pub mod types;

--- a/src/main.rs
+++ b/src/main.rs
@@ -189,6 +189,32 @@ fn seed_indexer_with_config_paths(
     report
 }
 
+/// Resolve whether a `Commands::Serve` invocation selects proxy mode.
+///
+/// Proxy mode never loads an `IndexFacade` in-process (§4.5): it discovers or
+/// spawns a backing `codanna serve --http` and relays stdio traffic to it. This
+/// mirrors the CLI-flag-then-config precedence in
+/// `cli::commands::serve::run` so the pre-dispatch resource predicates
+/// (`needs_indexer`, `needs_trait_resolver`, `needs_semantic_search`) agree
+/// with the mode `serve::run` will actually select.
+fn is_proxy_serve(command: &Commands, config: &Settings) -> bool {
+    match command {
+        Commands::Serve {
+            proxy: true,
+            http: false,
+            https: false,
+            ..
+        } => true,
+        Commands::Serve {
+            proxy: false,
+            http: false,
+            https: false,
+            ..
+        } => config.server.mode == "proxy",
+        _ => false,
+    }
+}
+
 fn create_facade_or_exit(settings: Arc<Settings>) -> IndexFacade {
     IndexFacade::new(settings).unwrap_or_else(|e| {
         eprintln!("Error: Failed to create index: {e}");
@@ -209,6 +235,19 @@ fn create_facade_or_exit(settings: Arc<Settings>) -> IndexFacade {
 /// Auto-initializes config for index command. Persists index after modifications.
 #[tokio::main]
 async fn main() {
+    // reqwest's `rustls-no-provider` backend (enabled transitively by the
+    // `https-server` feature, see Cargo.toml) requires a default rustls
+    // crypto provider installed before the FIRST `reqwest::Client` is built
+    // anywhere in this process, or that build panics with "No rustls crypto
+    // provider is configured" -- including the plain `--http` proxy path's
+    // client (src/mcp/proxy.rs), which never touches `serve_tls` at all.
+    // Installing it once, here, before any command dispatch, covers every
+    // `reqwest::Client` construction site regardless of which one runs first.
+    #[cfg(feature = "https-server")]
+    {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+    }
+
     let cli = Cli::parse();
 
     // For index command, auto-initialize if needed (but not when using --config)
@@ -278,7 +317,7 @@ async fn main() {
             | Commands::Plugin { .. }
             | Commands::Documents { .. }
             | Commands::Profile { .. }
-    );
+    ) && !is_proxy_serve(&cli.command, &config);
 
     // Initialize project resolution providers (only if needed)
     // This ensures caches are built before indexing starts
@@ -329,7 +368,7 @@ async fn main() {
             ..
         } | Commands::Index { .. }
             | Commands::Serve { .. }
-    );
+    ) && !is_proxy_serve(&cli.command, &config);
 
     // Determine if we need semantic search (ML model loading)
     // Retrieve commands use Tantivy text search only - no ML model needed
@@ -338,6 +377,7 @@ async fn main() {
             // Only these MCP tools need semantic search
             ["semantic_search_docs", "semantic_search_with_context"].contains(&tool.as_str())
         }
+        Commands::Serve { .. } if is_proxy_serve(&cli.command, &config) => false,
         Commands::Index { .. } | Commands::Serve { .. } => true,
         _ => false,
     };
@@ -623,6 +663,8 @@ async fn main() {
         }
     }
 
+    let serve_is_proxy = is_proxy_serve(&cli.command, &config);
+
     match cli.command {
         Commands::Init { force } => {
             codanna::cli::commands::init::run_init(force);
@@ -672,20 +714,31 @@ async fn main() {
             watch_interval,
             http,
             https,
+            proxy,
             bind,
         } => {
             use codanna::cli::commands::serve::{ServeArgs, run as run_serve};
+            // Proxy mode never loads an IndexFacade in-process (§4.5): the
+            // predicates above (needs_indexer/needs_trait_resolver/
+            // needs_semantic_search) already exclude it, so `indexer` is
+            // `None` here and must not be unwrapped.
+            let facade = if serve_is_proxy {
+                None
+            } else {
+                Some(indexer.expect("non-proxy serve requires indexer"))
+            };
             run_serve(
                 ServeArgs {
                     watch,
                     watch_interval,
                     http,
                     https,
+                    proxy,
                     bind,
                 },
                 config,
                 settings,
-                indexer.expect("serve requires indexer"),
+                facade,
                 index_path,
             )
             .await;
@@ -881,5 +934,52 @@ mod tests {
     fn verify_cli() {
         // This test ensures the CLI structure is valid
         Cli::command().debug_assert();
+    }
+}
+
+#[cfg(test)]
+mod is_proxy_serve_tests {
+    use super::*;
+
+    // `is_proxy_serve` is pure (Commands + Settings in, bool out) so precedence
+    // between the CLI `--proxy` flag and `config.server.mode` can be asserted
+    // hermetically here, mirroring `resolve_server_mode`'s precedence in
+    // `cli::commands::serve`.
+
+    fn serve_command(http: bool, https: bool, proxy: bool) -> Commands {
+        Commands::Serve {
+            watch: false,
+            watch_interval: 5,
+            http,
+            https,
+            proxy,
+            bind: "127.0.0.1:8080".to_string(),
+        }
+    }
+
+    #[test]
+    fn cli_proxy_flag_selects_proxy() {
+        let config = Settings::default();
+        assert!(is_proxy_serve(&serve_command(false, false, true), &config));
+    }
+
+    #[test]
+    fn config_server_mode_proxy_selects_proxy_for_bare_serve() {
+        let mut config = Settings::default();
+        config.server.mode = "proxy".to_string();
+        assert!(is_proxy_serve(&serve_command(false, false, false), &config));
+    }
+
+    #[test]
+    fn cli_http_flag_still_selects_http_over_config_proxy() {
+        let mut config = Settings::default();
+        config.server.mode = "proxy".to_string();
+        assert!(!is_proxy_serve(&serve_command(true, false, false), &config));
+    }
+
+    #[test]
+    fn non_serve_command_is_never_proxy() {
+        let config = Settings::default();
+        assert!(!is_proxy_serve(&Commands::Config, &config));
     }
 }

--- a/src/mcp/http_server.rs
+++ b/src/mcp/http_server.rs
@@ -3,6 +3,17 @@
 //! Provides a persistent HTTP server with streamable HTTP transport
 //! for multiple concurrent clients and real-time updates.
 
+/// Checks whether an `Authorization` header value carries the dev-mode
+/// Bearer token. Expects the standard "Bearer <token>" form; rmcp's
+/// `auth_header` adds the prefix, so the comparison strips it rather than
+/// composing a "Bearer <token>" literal.
+#[cfg(feature = "http-server")]
+fn is_authorized(auth_header: Option<&str>) -> bool {
+    auth_header
+        .and_then(|value| value.strip_prefix("Bearer "))
+        .is_some_and(|token| token == crate::mcp::DUMMY_BEARER_TOKEN)
+}
+
 #[cfg(feature = "http-server")]
 pub async fn serve_http(config: crate::Settings, watch: bool, bind: String) -> anyhow::Result<()> {
     use crate::IndexPersistence;
@@ -303,7 +314,7 @@ pub async fn serve_http(config: crate::Settings, watch: bool, bind: String) -> a
         if grant_type == "authorization_code" && code == "dummy-auth-code" {
             // Return access token WITHOUT refresh token
             axum::Json(serde_json::json!({
-                "access_token": "mcp-access-token-dummy",
+                "access_token": crate::mcp::DUMMY_BEARER_TOKEN,
                 "token_type": "Bearer",
                 "expires_in": 3600,
                 "scope": "mcp"
@@ -414,14 +425,13 @@ pub async fn serve_http(config: crate::Settings, watch: bool, bind: String) -> a
         next: axum::middleware::Next,
     ) -> Result<axum::response::Response, axum::http::StatusCode> {
         // Check for Bearer token in Authorization header
-        if let Some(auth_header) = req.headers().get("Authorization") {
-            if let Ok(auth_str) = auth_header.to_str() {
-                // Accept our dummy token
-                if auth_str == "Bearer mcp-access-token-dummy" {
-                    eprintln!("MCP request authorized with Bearer token");
-                    return Ok(next.run(req).await);
-                }
-            }
+        let auth_str = req
+            .headers()
+            .get("Authorization")
+            .and_then(|h| h.to_str().ok());
+        if is_authorized(auth_str) {
+            eprintln!("MCP request authorized with Bearer token");
+            return Ok(next.run(req).await);
         }
 
         // For OPTIONS requests (CORS preflight), allow without auth
@@ -455,10 +465,47 @@ pub async fn serve_http(config: crate::Settings, watch: bool, bind: String) -> a
 
     // Bind and serve
     let listener = tokio::net::TcpListener::bind(&bind).await?;
+    let actual_port = listener.local_addr()?.port();
     eprintln!("HTTP MCP server listening on http://{bind}");
     eprintln!("MCP endpoint: http://{bind}/mcp");
     eprintln!("Health check: http://{bind}/health");
     eprintln!("Press Ctrl+C to stop the server");
+
+    // Publish a discovery record under the tree's `.codanna/` so other tools
+    // (e.g. the CLI proxy) can find this server without guessing ports.
+    // `local_addr().port()` is read above rather than parsing `bind` so an
+    // ephemeral `:0` bind resolves to the actual assigned port.
+    //
+    // The directory is derived from the workspace root, not `index_path`:
+    // `index_path` may be absolute or resolved relative to a `--config`
+    // file's parent (`init::resolve_index_path`), so it can diverge from
+    // `.codanna` in exactly the cases `discover_or_spawn` relies on.
+    let codanna_dir = crate::serve_discovery::resolve_workspace_root(&config)
+        .map(|root| crate::serve_discovery::discovery_dir(&root));
+
+    match &codanna_dir {
+        Some(codanna_dir) => {
+            let serve_record = crate::serve_discovery::ServeRecord {
+                pid: std::process::id(),
+                port: actual_port,
+                scheme: crate::serve_discovery::ServeScheme::Http,
+            };
+            if let Err(e) = crate::serve_discovery::write_record(codanna_dir, &serve_record) {
+                tracing::warn!(target: "mcp", "failed to write serve discovery record: {e}");
+            }
+        }
+        None => {
+            tracing::warn!(
+                target: "mcp",
+                "no workspace root (.codanna) found; not publishing a discovery record -- \
+                 `codanna serve --proxy` cannot discover this server. Run `codanna init` in the project root."
+            );
+            eprintln!(
+                "Warning: no workspace root (.codanna) found; not publishing a discovery record -- \
+                 `codanna serve --proxy` cannot discover this server. Run `codanna init` in the project root."
+            );
+        }
+    }
 
     // Create server future
     let server = axum::serve(listener, router);
@@ -466,11 +513,17 @@ pub async fn serve_http(config: crate::Settings, watch: bool, bind: String) -> a
     // Handle graceful shutdown with tokio::select!
     tokio::select! {
         result = server => {
+            if let Some(codanna_dir) = &codanna_dir {
+                crate::serve_discovery::remove_record(codanna_dir);
+            }
             result?;
         }
         _ = shutdown_signal() => {
             eprintln!("Shutting down HTTP server...");
             ct.cancel();
+            if let Some(codanna_dir) = &codanna_dir {
+                crate::serve_discovery::remove_record(codanna_dir);
+            }
         }
     }
 
@@ -487,4 +540,29 @@ pub async fn serve_http(
     eprintln!("HTTP server support is not compiled in.");
     eprintln!("Please rebuild with: cargo build --features http-server");
     std::process::exit(1);
+}
+
+#[cfg(all(test, feature = "http-server"))]
+mod tests {
+    use super::is_authorized;
+
+    #[test]
+    fn accepts_bearer_prefixed_dummy_token() {
+        assert!(is_authorized(Some("Bearer mcp-access-token-dummy")));
+    }
+
+    #[test]
+    fn rejects_bare_token_without_bearer_prefix() {
+        assert!(!is_authorized(Some("mcp-access-token-dummy")));
+    }
+
+    #[test]
+    fn rejects_wrong_token() {
+        assert!(!is_authorized(Some("Bearer wrong")));
+    }
+
+    #[test]
+    fn rejects_missing_header() {
+        assert!(!is_authorized(None));
+    }
 }

--- a/src/mcp/https_server.rs
+++ b/src/mcp/https_server.rs
@@ -15,7 +15,6 @@ pub async fn serve_https(config: crate::Settings, watch: bool, bind: String) -> 
     use rmcp::transport::streamable_http_server::{
         StreamableHttpServerConfig, StreamableHttpService, session::local::LocalSessionManager,
     };
-    use std::net::SocketAddr;
     use std::path::PathBuf;
     use std::sync::Arc;
     use std::time::Duration;
@@ -293,8 +292,9 @@ pub async fn serve_https(config: crate::Settings, watch: bool, bind: String) -> 
         .await
         .context("Failed to configure TLS")?;
 
-    // Parse bind address
-    let addr: SocketAddr = bind.parse().context("Failed to parse bind address")?;
+    // Bind and read back the actual assigned port
+    let listener = tokio::net::TcpListener::bind(&bind).await?;
+    let actual_port = listener.local_addr()?.port();
 
     eprintln!("HTTPS MCP server listening on https://{bind}");
     eprintln!("MCP endpoint: https://{bind}/mcp");
@@ -305,17 +305,63 @@ pub async fn serve_https(config: crate::Settings, watch: bool, bind: String) -> 
     eprintln!();
     eprintln!("Press Ctrl+C to stop the server");
 
-    // Serve with TLS
-    let server = axum_server::bind_rustls(addr, tls_config).serve(router.into_make_service());
+    // Publish a discovery record under the tree's `.codanna/` so other tools
+    // (e.g. the CLI proxy) can find this server without guessing ports.
+    // `local_addr().port()` is read above rather than parsing `bind` so an
+    // ephemeral `:0` bind resolves to the actual assigned port.
+    //
+    // The directory is derived from the workspace root, not `index_path`:
+    // `index_path` may be absolute or resolved relative to a `--config`
+    // file's parent (`init::resolve_index_path`), so it can diverge from
+    // `.codanna` in exactly the cases `discover_or_spawn` relies on.
+    let codanna_dir = crate::serve_discovery::resolve_workspace_root(&config)
+        .map(|root| crate::serve_discovery::discovery_dir(&root));
+
+    match &codanna_dir {
+        Some(codanna_dir) => {
+            let serve_record = crate::serve_discovery::ServeRecord {
+                pid: std::process::id(),
+                port: actual_port,
+                scheme: crate::serve_discovery::ServeScheme::Https,
+            };
+            if let Err(e) = crate::serve_discovery::write_record(codanna_dir, &serve_record) {
+                tracing::warn!(target: "mcp", "failed to write serve discovery record: {e}");
+            }
+        }
+        None => {
+            tracing::warn!(
+                target: "mcp",
+                "no workspace root (.codanna) found; not publishing a discovery record -- \
+                 `codanna serve --proxy` cannot discover this server. Run `codanna init` in the project root."
+            );
+            eprintln!(
+                "Warning: no workspace root (.codanna) found; not publishing a discovery record -- \
+                 `codanna serve --proxy` cannot discover this server. Run `codanna init` in the project root."
+            );
+        }
+    }
+
+    // Convert to std listener for axum_server's Rustls acceptor. `into_std`
+    // preserves the non-blocking mode tokio's listener already has, which
+    // `from_tcp_rustls` requires.
+    let std_listener = listener.into_std()?;
+    let server =
+        axum_server::from_tcp_rustls(std_listener, tls_config)?.serve(router.into_make_service());
 
     // Handle graceful shutdown
     tokio::select! {
         result = server => {
+            if let Some(codanna_dir) = &codanna_dir {
+                crate::serve_discovery::remove_record(codanna_dir);
+            }
             result?;
         }
         _ = shutdown_signal() => {
             eprintln!("Shutting down HTTPS server...");
             ct.cancel();
+            if let Some(codanna_dir) = &codanna_dir {
+                crate::serve_discovery::remove_record(codanna_dir);
+            }
         }
     }
 
@@ -378,7 +424,7 @@ async fn oauth_token(body: String) -> axum::Json<serde_json::Value> {
     if grant_type == "authorization_code" && code == "dummy-auth-code" {
         // Return access token WITHOUT refresh token
         axum::Json(serde_json::json!({
-            "access_token": "mcp-access-token-dummy",
+            "access_token": crate::mcp::DUMMY_BEARER_TOKEN,
             "token_type": "Bearer",
             "expires_in": 3600,
             "scope": "mcp"
@@ -511,14 +557,16 @@ async fn get_or_create_certificate(bind: &str) -> anyhow::Result<(Vec<u8>, Vec<u
     use anyhow::Context;
     use rcgen::generate_simple_self_signed;
 
-    // Determine certificate storage directory
-    let cert_dir = dirs::config_dir()
-        .context("Failed to get config directory")?
-        .join("codanna")
-        .join("certs");
-
-    let cert_path = cert_dir.join("server.pem");
-    let key_path = cert_dir.join("server.key");
+    // Cert/key paths come from the single definition in `serve_tls::cert_paths`
+    // -- this is the same path `serve_tls::pinned_client` pins its trust to, so
+    // the writer here and that reader must never compute this join separately
+    // or they will silently drift onto different files.
+    let (cert_path, key_path) = crate::serve_tls::cert_paths()
+        .context("Failed to determine config directory for certificate storage")?;
+    let cert_dir = cert_path
+        .parent()
+        .context("Certificate path has no parent directory")?
+        .to_path_buf();
 
     // Create directory if it doesn't exist
     tokio::fs::create_dir_all(&cert_dir)

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -21,10 +21,16 @@ pub mod client;
 pub mod http_server;
 pub mod https_server;
 pub mod notifications;
+pub mod proxy;
 pub mod requests;
 pub mod server;
 pub mod service;
 pub mod tools;
 
+pub use proxy::{ProxyError, ProxyResult, serve_proxy};
 pub use requests::*;
 pub use server::{CodeIntelligenceServer, format_relative_time};
+
+/// Bearer token accepted by the dev-mode auth middleware. Bare token — rmcp
+/// `auth_header` adds the "Bearer " prefix itself.
+pub(crate) const DUMMY_BEARER_TOKEN: &str = "mcp-access-token-dummy";

--- a/src/mcp/proxy.rs
+++ b/src/mcp/proxy.rs
@@ -1,0 +1,420 @@
+//! stdio<->HTTP delegating MCP proxy.
+//!
+//! `codanna serve --proxy` (or `server.mode = "proxy"` in `settings.toml`)
+//! speaks stdio to the connecting MCP client while delegating every request
+//! to a backing `codanna serve --http` process, discovered or spawned via
+//! [`crate::serve_discovery::discover_or_spawn`]. This lets several stdio
+//! clients (e.g. multiple AI-tool subagents rooted at the same workspace)
+//! share one HTTP-mode index/tantivy writer without each holding its own
+//! `IndexFacade` -- the proxy process itself never constructs one.
+//!
+//! ## Scope for this PR
+//!
+//! - Request/response delegation across the full `ServerHandler` surface
+//!   (tools, resources, prompts, completion, custom requests).
+//! - Best-effort forwarding of server-initiated notifications (logging,
+//!   resource/tool/prompt list-changed, resource-updated, progress) from the
+//!   upstream HTTP server down to the stdio client.
+//!
+//! ## Explicitly out of scope
+//!
+//! A byte-level transparent transport relay -- splicing the stdio and HTTP
+//! transports directly instead of round-tripping through typed rmcp
+//! requests/responses -- is an optional later optimization. It would remove
+//! one layer of (de)serialization but adds real complexity (framing,
+//! backpressure, session lifecycle) that isn't justified until the
+//! request/response delegation implemented here is proven in practice.
+
+// Logging notifications and `set_level` are deprecated by SEP-2577, but this
+// module forwards the full `ServerHandler`/`ClientHandler` surface
+// (including logging) for client compatibility, mirroring the same
+// allowance already used in `mcp::server` and `mcp::notifications`.
+#![allow(deprecated)]
+
+use std::sync::Arc;
+
+use rmcp::model::{
+    CallToolRequestParams, CallToolResult, ClientRequest, CompleteRequestParams, CompleteResult,
+    CustomRequest, CustomResult, ErrorData as McpError, GetPromptRequestParams, GetPromptResult,
+    Implementation, InitializeRequestParams, InitializeResult, ListPromptsResult,
+    ListResourceTemplatesResult, ListResourcesResult, ListToolsResult,
+    LoggingMessageNotificationParam, PaginatedRequestParams, ProgressNotificationParam,
+    ReadResourceRequestParams, ReadResourceResult, ResourceUpdatedNotificationParam,
+    ServerCapabilities, ServerInfo, ServerResult, SetLevelRequestParams, SubscribeRequestParams,
+    UnsubscribeRequestParams,
+};
+use rmcp::service::{
+    NotificationContext, Peer, RequestContext, RoleClient, RoleServer, RunningService, ServiceError,
+};
+use rmcp::transport::StreamableHttpClientTransport;
+use rmcp::transport::streamable_http_client::StreamableHttpClientTransportConfig;
+use rmcp::{ClientHandler, ServerHandler, ServiceExt};
+use thiserror::Error;
+use tokio::sync::Mutex;
+
+use crate::config::Settings;
+use crate::mcp::DUMMY_BEARER_TOKEN;
+use crate::serve_discovery::{self, DiscoveryError, ServeScheme};
+use crate::serve_tls;
+
+/// Errors from establishing or running the stdio<->HTTP proxy.
+#[derive(Debug, Error)]
+pub enum ProxyError {
+    #[error(
+        "could not resolve workspace root: no '.codanna' directory found in the current directory or its ancestors"
+    )]
+    NoWorkspaceRoot,
+
+    #[error("failed to discover/spawn backing HTTP server: {0}")]
+    Discovery(#[from] DiscoveryError),
+
+    #[error("failed to connect to backing HTTP server: {0}")]
+    UpstreamConnect(String),
+
+    #[error("stdio transport error: {0}")]
+    Stdio(String),
+
+    #[error("failed to build TLS-pinned client for backing HTTPS server: {0}")]
+    Tls(#[from] crate::serve_tls::TlsClientError),
+}
+
+pub type ProxyResult<T> = Result<T, ProxyError>;
+
+/// Converts an upstream `ServiceError` into the `McpError` shape expected by
+/// `ServerHandler` methods. A `ServiceError::McpError` already carries a
+/// well-formed protocol error and is passed through unchanged; every other
+/// variant (transport closed, timeout, cancellation, ...) becomes an
+/// internal error describing the underlying delegation failure.
+fn map_service_err(err: ServiceError) -> McpError {
+    match err {
+        ServiceError::McpError(e) => e,
+        other => McpError::internal_error(format!("proxy delegation failed: {other}"), None),
+    }
+}
+
+/// `ClientHandler` for the connection to the backing HTTP MCP server.
+///
+/// Its only job is forwarding server-initiated notifications down to the
+/// stdio client once the downstream `initialize` handshake has populated
+/// `downstream`. Before that point (a narrow window right at startup)
+/// notifications are dropped rather than buffered, since there is no
+/// downstream peer yet to forward them to.
+#[derive(Clone, Default)]
+struct NotificationRelay {
+    downstream: Arc<Mutex<Option<Peer<RoleServer>>>>,
+}
+
+impl ClientHandler for NotificationRelay {
+    async fn on_logging_message(
+        &self,
+        params: LoggingMessageNotificationParam,
+        _context: NotificationContext<RoleClient>,
+    ) {
+        if let Some(peer) = self.downstream.lock().await.as_ref() {
+            // Logging notifications are deprecated by SEP-2577; forward them
+            // anyway for client compatibility, mirroring `CodeIntelligenceServer`.
+            #[allow(deprecated)]
+            let _ = peer.notify_logging_message(params).await;
+        }
+    }
+
+    async fn on_resource_updated(
+        &self,
+        params: ResourceUpdatedNotificationParam,
+        _context: NotificationContext<RoleClient>,
+    ) {
+        if let Some(peer) = self.downstream.lock().await.as_ref() {
+            let _ = peer.notify_resource_updated(params).await;
+        }
+    }
+
+    async fn on_resource_list_changed(&self, _context: NotificationContext<RoleClient>) {
+        if let Some(peer) = self.downstream.lock().await.as_ref() {
+            let _ = peer.notify_resource_list_changed().await;
+        }
+    }
+
+    async fn on_tool_list_changed(&self, _context: NotificationContext<RoleClient>) {
+        if let Some(peer) = self.downstream.lock().await.as_ref() {
+            let _ = peer.notify_tool_list_changed().await;
+        }
+    }
+
+    async fn on_prompt_list_changed(&self, _context: NotificationContext<RoleClient>) {
+        if let Some(peer) = self.downstream.lock().await.as_ref() {
+            let _ = peer.notify_prompt_list_changed().await;
+        }
+    }
+
+    async fn on_progress(
+        &self,
+        params: ProgressNotificationParam,
+        _context: NotificationContext<RoleClient>,
+    ) {
+        if let Some(peer) = self.downstream.lock().await.as_ref() {
+            let _ = peer.notify_progress(params).await;
+        }
+    }
+}
+
+/// `ServerHandler` facing the stdio client. Every request is delegated to the
+/// upstream HTTP MCP server; this process holds no `IndexFacade` and no
+/// index state of its own.
+#[derive(Clone)]
+struct DelegatingProxyHandler {
+    upstream: Arc<RunningService<RoleClient, NotificationRelay>>,
+    downstream: Arc<Mutex<Option<Peer<RoleServer>>>>,
+}
+
+impl ServerHandler for DelegatingProxyHandler {
+    fn get_info(&self) -> ServerInfo {
+        // Reflect the upstream server's negotiated capabilities/info when
+        // available (set during the upstream `initialize` handshake that
+        // already completed by the time this proxy starts serving stdio);
+        // fall back to a minimal description if it is somehow unset.
+        self.upstream
+            .peer_info()
+            .map(|info| (*info).clone())
+            .unwrap_or_else(|| {
+                ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+                    .with_server_info(Implementation::new(
+                        "codanna-proxy",
+                        env!("CARGO_PKG_VERSION"),
+                    ))
+            })
+    }
+
+    async fn initialize(
+        &self,
+        request: InitializeRequestParams,
+        context: RequestContext<RoleServer>,
+    ) -> Result<InitializeResult, McpError> {
+        if context.peer.peer_info().is_none() {
+            context.peer.set_peer_info(request);
+        }
+
+        *self.downstream.lock().await = Some(context.peer.clone());
+
+        Ok(self.get_info())
+    }
+
+    async fn list_tools(
+        &self,
+        request: Option<PaginatedRequestParams>,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<ListToolsResult, McpError> {
+        self.upstream
+            .list_tools(request)
+            .await
+            .map_err(map_service_err)
+    }
+
+    async fn call_tool(
+        &self,
+        request: CallToolRequestParams,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, McpError> {
+        self.upstream
+            .call_tool(request)
+            .await
+            .map_err(map_service_err)
+    }
+
+    async fn list_resources(
+        &self,
+        request: Option<PaginatedRequestParams>,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<ListResourcesResult, McpError> {
+        self.upstream
+            .list_resources(request)
+            .await
+            .map_err(map_service_err)
+    }
+
+    async fn list_resource_templates(
+        &self,
+        request: Option<PaginatedRequestParams>,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<ListResourceTemplatesResult, McpError> {
+        self.upstream
+            .list_resource_templates(request)
+            .await
+            .map_err(map_service_err)
+    }
+
+    async fn read_resource(
+        &self,
+        request: ReadResourceRequestParams,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<ReadResourceResult, McpError> {
+        self.upstream
+            .read_resource(request)
+            .await
+            .map_err(map_service_err)
+    }
+
+    async fn list_prompts(
+        &self,
+        request: Option<PaginatedRequestParams>,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<ListPromptsResult, McpError> {
+        self.upstream
+            .list_prompts(request)
+            .await
+            .map_err(map_service_err)
+    }
+
+    async fn get_prompt(
+        &self,
+        request: GetPromptRequestParams,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<GetPromptResult, McpError> {
+        self.upstream
+            .get_prompt(request)
+            .await
+            .map_err(map_service_err)
+    }
+
+    async fn complete(
+        &self,
+        request: CompleteRequestParams,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<CompleteResult, McpError> {
+        self.upstream
+            .complete(request)
+            .await
+            .map_err(map_service_err)
+    }
+
+    async fn set_level(
+        &self,
+        request: SetLevelRequestParams,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<(), McpError> {
+        self.upstream
+            .set_level(request)
+            .await
+            .map_err(map_service_err)
+    }
+
+    async fn subscribe(
+        &self,
+        request: SubscribeRequestParams,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<(), McpError> {
+        self.upstream
+            .subscribe(request)
+            .await
+            .map_err(map_service_err)
+    }
+
+    async fn unsubscribe(
+        &self,
+        request: UnsubscribeRequestParams,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<(), McpError> {
+        self.upstream
+            .unsubscribe(request)
+            .await
+            .map_err(map_service_err)
+    }
+
+    async fn on_custom_request(
+        &self,
+        request: CustomRequest,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<CustomResult, McpError> {
+        match self
+            .upstream
+            .peer()
+            .send_request(ClientRequest::CustomRequest(request))
+            .await
+        {
+            Ok(ServerResult::CustomResult(custom)) => Ok(custom),
+            Ok(other) => Err(McpError::internal_error(
+                format!("unexpected upstream response to custom request: {other:?}"),
+                None,
+            )),
+            Err(e) => Err(map_service_err(e)),
+        }
+    }
+}
+
+/// Run the stdio<->HTTP delegating proxy until the stdio transport closes.
+///
+/// No `IndexFacade` is constructed in this process: discovery/spawn of the
+/// backing HTTP server (and all index state) lives entirely in the process
+/// `serve_discovery::discover_or_spawn` finds or launches.
+pub async fn serve_proxy(config: Settings) -> ProxyResult<()> {
+    let workspace_root =
+        serve_discovery::resolve_workspace_root(&config).ok_or(ProxyError::NoWorkspaceRoot)?;
+
+    eprintln!(
+        "Proxy: discovering backing HTTP MCP server for {}",
+        workspace_root.display()
+    );
+    let record = serve_discovery::discover_or_spawn(&workspace_root, &config).await?;
+    eprintln!(
+        "Proxy: delegating to backing MCP server at {}://127.0.0.1:{} (pid {})",
+        record.scheme.as_str(),
+        record.port,
+        record.pid
+    );
+
+    let transport_config = StreamableHttpClientTransportConfig::with_uri(format!(
+        "{}://127.0.0.1:{}/mcp",
+        record.scheme.as_str(),
+        record.port
+    ))
+    .auth_header(DUMMY_BEARER_TOKEN);
+
+    let downstream: Arc<Mutex<Option<Peer<RoleServer>>>> = Arc::new(Mutex::new(None));
+    let relay = NotificationRelay {
+        downstream: downstream.clone(),
+    };
+
+    let upstream = match record.scheme {
+        // `from_config` uses rmcp's own bundled reqwest client (gated behind
+        // the `transport-streamable-http-client-reqwest` feature) rather than
+        // a hand-rolled HTTP client, per the preference for rmcp's default
+        // client transport.
+        ServeScheme::Http => {
+            let transport = StreamableHttpClientTransport::from_config(transport_config);
+            relay
+                .serve(transport)
+                .await
+                .map_err(|e| ProxyError::UpstreamConnect(e.to_string()))?
+        }
+        // The backing server is `--https`: dial it ONLY through the
+        // cert-pinning client (`serve_tls::pinned_client`), never through
+        // `from_config`'s bundled client. A pinning failure (missing/mismatched
+        // persisted cert) must fail the proxy outright rather than silently
+        // falling back to an unauthenticated/plaintext-trusting transport.
+        ServeScheme::Https => {
+            let client = serve_tls::pinned_client()?;
+            let transport = StreamableHttpClientTransport::with_client(client, transport_config);
+            relay
+                .serve(transport)
+                .await
+                .map_err(|e| ProxyError::UpstreamConnect(e.to_string()))?
+        }
+    };
+
+    let handler = DelegatingProxyHandler {
+        upstream: Arc::new(upstream),
+        downstream,
+    };
+
+    use rmcp::transport::stdio;
+    let service = handler
+        .serve(stdio())
+        .await
+        .map_err(|e| ProxyError::Stdio(e.to_string()))?;
+
+    service
+        .waiting()
+        .await
+        .map_err(|e| ProxyError::Stdio(e.to_string()))?;
+
+    Ok(())
+}

--- a/src/parsing/c/audit.rs
+++ b/src/parsing/c/audit.rs
@@ -4,7 +4,6 @@
 //! This helps identify gaps in our symbol extraction.
 
 use super::CParser;
-use crate::io::format::format_utc_timestamp;
 use crate::parsing::NodeTracker;
 use crate::types::FileId;
 use std::collections::{HashMap, HashSet};
@@ -98,7 +97,6 @@ impl CParserAudit {
         let mut report = String::new();
 
         report.push_str("# C Parser Coverage Report\n\n");
-        report.push_str(&format!("*Generated: {}*\n\n", format_utc_timestamp()));
 
         // Key nodes we care about for symbol extraction
         let key_nodes = vec![

--- a/src/parsing/clojure/audit.rs
+++ b/src/parsing/clojure/audit.rs
@@ -4,7 +4,6 @@
 //! This helps identify gaps in our symbol extraction.
 
 use super::ClojureParser;
-use crate::io::format::format_utc_timestamp;
 use crate::parsing::NodeTracker;
 use crate::parsing::parser::LanguageParser;
 use crate::types::FileId;
@@ -89,7 +88,6 @@ impl ClojureParserAudit {
         let mut report = String::new();
 
         report.push_str("# Clojure Parser Symbol Extraction Coverage Report\n\n");
-        report.push_str(&format!("*Generated: {}*\n\n", format_utc_timestamp()));
 
         // Key nodes we care about for symbol extraction in Clojure
         let key_nodes = vec![

--- a/src/parsing/cpp/audit.rs
+++ b/src/parsing/cpp/audit.rs
@@ -4,7 +4,6 @@
 //! This helps identify gaps in our symbol extraction.
 
 use super::CppParser;
-use crate::io::format::format_utc_timestamp;
 use crate::parsing::NodeTracker;
 use crate::types::FileId;
 use std::collections::{HashMap, HashSet};
@@ -99,7 +98,6 @@ impl CppParserAudit {
         let mut report = String::new();
 
         report.push_str("# C++ Parser Coverage Report\n\n");
-        report.push_str(&format!("*Generated: {}*\n\n", format_utc_timestamp()));
 
         // Key nodes we care about for symbol extraction
         // NOTE: These are ACTUAL tree-sitter node names only.

--- a/src/parsing/csharp/audit.rs
+++ b/src/parsing/csharp/audit.rs
@@ -4,7 +4,6 @@
 //! This helps identify gaps in our symbol extraction.
 
 use super::CSharpParser;
-use crate::io::format::format_utc_timestamp;
 use crate::parsing::NodeTracker;
 use crate::types::FileId;
 use std::collections::{HashMap, HashSet};
@@ -88,7 +87,6 @@ impl CSharpParserAudit {
         let mut report = String::new();
 
         report.push_str("# C# Parser Coverage Report\n\n");
-        report.push_str(&format!("*Generated: {}*\n\n", format_utc_timestamp()));
 
         // Key nodes we care about for symbol extraction (C# specific)
         let key_nodes = vec![

--- a/src/parsing/gdscript/audit.rs
+++ b/src/parsing/gdscript/audit.rs
@@ -4,7 +4,6 @@
 //! grammar exposed by tree-sitter-gdscript. This helps highlight extraction gaps.
 
 use super::GdscriptParser;
-use crate::io::format::format_utc_timestamp;
 use crate::parsing::parser::LanguageParser;
 use crate::types::{FileId, SymbolCounter};
 use std::collections::{HashMap, HashSet};
@@ -85,7 +84,6 @@ impl GdscriptParserAudit {
         let mut report = String::new();
 
         report.push_str("# GDScript Parser Symbol Extraction Coverage Report\n\n");
-        report.push_str(&format!("*Generated: {}*\n\n", format_utc_timestamp()));
 
         let key_nodes = vec![
             "class_definition",

--- a/src/parsing/go/audit.rs
+++ b/src/parsing/go/audit.rs
@@ -4,7 +4,6 @@
 //! This helps identify gaps in our symbol extraction.
 
 use super::GoParser;
-use crate::io::format::format_utc_timestamp;
 use crate::parsing::NodeTracker;
 use crate::types::FileId;
 use std::collections::{HashMap, HashSet};
@@ -88,7 +87,6 @@ impl GoParserAudit {
         let mut report = String::new();
 
         report.push_str("# Go Parser Symbol Extraction Coverage Report\n\n");
-        report.push_str(&format!("*Generated: {}*\n\n", format_utc_timestamp()));
 
         // Key nodes relevant for symbol extraction (not punctuation/operators)
         let key_nodes = vec![

--- a/src/parsing/java/audit.rs
+++ b/src/parsing/java/audit.rs
@@ -3,7 +3,6 @@
 //! Provides ABI-15 coverage tracking for Java parser.
 
 use super::JavaParser;
-use crate::io::format::format_utc_timestamp;
 use crate::parsing::{LanguageParser, NodeTracker};
 use crate::types::FileId;
 use std::collections::{HashMap, HashSet};
@@ -79,7 +78,6 @@ impl JavaParserAudit {
         let mut report = String::new();
 
         report.push_str("# Java Parser Symbol Extraction Coverage Report\n\n");
-        report.push_str(&format!("*Generated: {}*\n\n", format_utc_timestamp()));
 
         let key_nodes = vec![
             "class_declaration",

--- a/src/parsing/javascript/audit.rs
+++ b/src/parsing/javascript/audit.rs
@@ -4,7 +4,6 @@
 //! This helps identify gaps in our symbol extraction.
 
 use super::JavaScriptParser;
-use crate::io::format::format_utc_timestamp;
 use crate::parsing::NodeTracker;
 use crate::types::FileId;
 use std::collections::{HashMap, HashSet};
@@ -88,7 +87,6 @@ impl JavaScriptParserAudit {
         let mut report = String::new();
 
         report.push_str("# JavaScript Parser Coverage Report\n\n");
-        report.push_str(&format!("*Generated: {}*\n\n", format_utc_timestamp()));
 
         // Key nodes we care about for symbol extraction (JavaScript-specific)
         let key_nodes = vec![

--- a/src/parsing/kotlin/audit.rs
+++ b/src/parsing/kotlin/audit.rs
@@ -4,7 +4,6 @@
 //! grammar exposed by tree-sitter-kotlin. This helps highlight extraction gaps.
 
 use super::KotlinParser;
-use crate::io::format::format_utc_timestamp;
 use crate::parsing::parser::LanguageParser;
 use crate::types::{FileId, SymbolCounter};
 use std::collections::{HashMap, HashSet};
@@ -85,7 +84,6 @@ impl KotlinParserAudit {
         let mut report = String::new();
 
         report.push_str("# Kotlin Parser Symbol Extraction Coverage Report\n\n");
-        report.push_str(&format!("*Generated: {}*\n\n", format_utc_timestamp()));
 
         let key_nodes = vec![
             "class_declaration",

--- a/src/parsing/lua/audit.rs
+++ b/src/parsing/lua/audit.rs
@@ -3,7 +3,6 @@
 //! Tracks which AST nodes the parser handles vs what's available in the grammar.
 
 use super::LuaParser;
-use crate::io::format::format_utc_timestamp;
 use crate::parsing::NodeTracker;
 use crate::types::FileId;
 use std::collections::{HashMap, HashSet};
@@ -77,7 +76,6 @@ impl LuaParserAudit {
         let mut report = String::new();
 
         report.push_str("# Lua Parser Symbol Extraction Coverage Report\n\n");
-        report.push_str(&format!("*Generated: {}*\n\n", format_utc_timestamp()));
 
         let key_nodes = vec![
             "chunk",

--- a/src/parsing/php/audit.rs
+++ b/src/parsing/php/audit.rs
@@ -4,7 +4,6 @@
 //! This helps identify gaps in our symbol extraction.
 
 use super::PhpParser;
-use crate::io::format::format_utc_timestamp;
 use crate::parsing::NodeTracker;
 use crate::types::FileId;
 use std::collections::{HashMap, HashSet};
@@ -88,7 +87,6 @@ impl PhpParserAudit {
         let mut report = String::new();
 
         report.push_str("# PHP Parser Coverage Report\n\n");
-        report.push_str(&format!("*Generated: {}*\n\n", format_utc_timestamp()));
 
         // Key nodes we care about for symbol extraction
         let key_nodes = vec![

--- a/src/parsing/python/audit.rs
+++ b/src/parsing/python/audit.rs
@@ -4,7 +4,6 @@
 //! This helps identify gaps in our symbol extraction.
 
 use super::PythonParser;
-use crate::io::format::format_utc_timestamp;
 use crate::parsing::NodeTracker;
 use crate::types::FileId;
 use std::collections::{HashMap, HashSet};
@@ -88,7 +87,6 @@ impl PythonParserAudit {
         let mut report = String::new();
 
         report.push_str("# Python Parser Symbol Extraction Coverage Report\n\n");
-        report.push_str(&format!("*Generated: {}*\n\n", format_utc_timestamp()));
 
         // Key nodes we care about for symbol extraction
         // Note: Python grammar uses function_definition for both sync and async functions

--- a/src/parsing/rust/audit.rs
+++ b/src/parsing/rust/audit.rs
@@ -4,7 +4,6 @@
 //! This helps identify gaps in our symbol extraction.
 
 use super::RustParser;
-use crate::io::format::format_utc_timestamp;
 use crate::parsing::NodeTracker;
 use crate::types::FileId;
 use std::collections::{HashMap, HashSet};
@@ -88,7 +87,6 @@ impl RustParserAudit {
         let mut report = String::new();
 
         report.push_str("# Rust Parser Coverage Report\n\n");
-        report.push_str(&format!("*Generated: {}*\n\n", format_utc_timestamp()));
 
         // Key nodes we care about for symbol extraction
         let key_nodes = vec![

--- a/src/parsing/swift/audit.rs
+++ b/src/parsing/swift/audit.rs
@@ -4,7 +4,6 @@
 //! grammar exposed by tree-sitter-swift. Highlights extraction gaps.
 
 use super::SwiftParser;
-use crate::io::format::format_utc_timestamp;
 use crate::parsing::parser::{LanguageParser, NodeTracker};
 use crate::types::{FileId, SymbolCounter};
 use std::collections::{HashMap, HashSet};
@@ -85,7 +84,6 @@ impl SwiftParserAudit {
         let mut report = String::new();
 
         report.push_str("# Swift Parser Symbol Extraction Coverage Report\n\n");
-        report.push_str(&format!("*Generated: {}*\n\n", format_utc_timestamp()));
 
         // Key nodes for Swift - includes class_declaration which covers class/struct/enum/actor/extension
         let key_nodes = vec![

--- a/src/parsing/typescript/audit.rs
+++ b/src/parsing/typescript/audit.rs
@@ -4,7 +4,6 @@
 //! This helps identify gaps in our symbol extraction.
 
 use super::TypeScriptParser;
-use crate::io::format::format_utc_timestamp;
 use crate::parsing::NodeTracker;
 use crate::types::FileId;
 use std::collections::{HashMap, HashSet};
@@ -89,7 +88,6 @@ impl TypeScriptParserAudit {
         let mut report = String::new();
 
         report.push_str("# TypeScript Parser Coverage Report\n\n");
-        report.push_str(&format!("*Generated: {}*\n\n", format_utc_timestamp()));
 
         // Key nodes we care about for symbol extraction
         let key_nodes = vec![

--- a/src/serve_discovery.rs
+++ b/src/serve_discovery.rs
@@ -1,0 +1,1077 @@
+//! Per-tree MCP serve discovery record.
+//!
+//! When an HTTP MCP server starts for a project tree, it writes a small
+//! `.codanna/serve.json` record `{pid, port}` so other tools (e.g. the CLI
+//! proxy) can discover a running server without guessing ports. The record
+//! is written atomically (temp file + rename) at mode 0600 and removed on
+//! graceful shutdown.
+
+use std::fs::OpenOptions;
+use std::io::{self, Read, Write};
+use std::net::TcpStream;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::config::Settings;
+
+/// Scheme of the backing MCP server named by a [`ServeRecord`].
+///
+/// Defaults to `Http` so that legacy `serve.json` records written before this
+/// field existed (no `scheme` key at all) deserialize as `Http` via
+/// `#[serde(default)]` on `ServeRecord::scheme`, rather than failing to parse.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ServeScheme {
+    #[default]
+    Http,
+    Https,
+}
+
+impl ServeScheme {
+    /// The scheme as used when building a URI (`"http"` / `"https"`).
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ServeScheme::Http => "http",
+            ServeScheme::Https => "https",
+        }
+    }
+}
+
+/// Discovery record written to `.codanna/serve.json`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ServeRecord {
+    pub pid: u32,
+    pub port: u16,
+    #[serde(default)]
+    pub scheme: ServeScheme,
+}
+
+/// Errors from reading/writing the serve discovery record.
+#[derive(Error, Debug)]
+pub enum DiscoveryError {
+    #[error("failed to create directory '{path}': {source}")]
+    CreateDir { path: PathBuf, source: io::Error },
+
+    #[error("failed to write serve record '{path}': {source}")]
+    Write { path: PathBuf, source: io::Error },
+
+    #[error("failed to set permissions on '{path}': {source}")]
+    Permissions { path: PathBuf, source: io::Error },
+
+    #[error("failed to rename '{from}' to '{to}': {source}")]
+    Rename {
+        from: PathBuf,
+        to: PathBuf,
+        source: io::Error,
+    },
+
+    #[error("failed to serialize serve record: {0}")]
+    Serialize(#[from] serde_json::Error),
+
+    #[error(
+        "failed to acquire spawn lock '{path}': {source}; if this persists, inspect '{path}' for a stale lock left by a crashed process"
+    )]
+    LockIo { path: PathBuf, source: io::Error },
+
+    #[error(
+        "failed to determine current executable path to spawn the backing 'codanna serve' process: {source}"
+    )]
+    CurrentExe { source: io::Error },
+
+    #[error(
+        "failed to spawn backing 'codanna serve' process: {source}; verify the codanna binary is on PATH and '{workspace_root}' is writable"
+    )]
+    Spawn {
+        workspace_root: PathBuf,
+        source: io::Error,
+    },
+
+    #[error(
+        "backing 'codanna serve --http' did not become healthy within {timeout_ms}ms; inspect the spawn lock at '{lock_path}' and the discovery record at '{record_path}' for a stuck or crashed process"
+    )]
+    SpawnTimeout {
+        timeout_ms: u64,
+        lock_path: PathBuf,
+        record_path: PathBuf,
+    },
+
+    #[error(
+        "no codanna configuration found for '{workspace_root}' (expected '{config_path}'); refusing to spawn a backing server for an unconfigured tree -- run 'codanna init' in the intended project root first"
+    )]
+    NoConfiguration {
+        workspace_root: PathBuf,
+        config_path: PathBuf,
+    },
+
+    #[error(
+        "no backing 'codanna serve --http' is running for '{workspace_root}' and auto-spawn is disabled ([server] auto_spawn = false in '{config_path}'); start one manually with 'codanna serve --http --watch', or set auto_spawn = true to let the proxy spawn it"
+    )]
+    AutoSpawnDisabled {
+        workspace_root: PathBuf,
+        config_path: PathBuf,
+    },
+}
+
+pub type DiscoveryResult<T> = Result<T, DiscoveryError>;
+
+/// Resolve the workspace root to key discovery off of: prefer the already
+/// -resolved `Settings::workspace_root`, falling back to walking up from the
+/// current directory for a `.codanna` directory.
+///
+/// The `.or_else(Settings::workspace_root)` fallback is load-bearing, not
+/// defensive: `Settings::load_from` (the `--config` code path) does not
+/// populate `workspace_root`, unlike `Settings::load`. A helper that reads
+/// only `config.workspace_root` would introduce a divergence in exactly the
+/// `--config` case, so both fields must be considered here.
+pub(crate) fn resolve_workspace_root(config: &Settings) -> Option<PathBuf> {
+    config
+        .workspace_root
+        .clone()
+        .or_else(Settings::workspace_root)
+}
+
+/// Derive the `.codanna` discovery-record directory for `workspace_root`.
+///
+/// This is deliberately NOT `index_path.parent()`: `index_path` may be
+/// absolute or resolved relative to a `--config` file's parent
+/// (`init::resolve_index_path`), so its parent only coincides with
+/// `.codanna` in the default, unconfigured case. Deriving from
+/// `workspace_root` instead keeps `serve --http` and `discover_or_spawn`
+/// agreeing on the same directory regardless of how `index_path` was
+/// customized.
+pub(crate) fn discovery_dir(workspace_root: &Path) -> PathBuf {
+    workspace_root.join(crate::init::local_dir_name())
+}
+
+fn record_path(codanna_dir: &Path) -> PathBuf {
+    codanna_dir.join("serve.json")
+}
+
+/// Write `record` to `<codanna_dir>/serve.json` atomically at mode 0600.
+///
+/// The record is first written to a sibling temp file, permissions are set,
+/// then it is renamed into place. This mirrors the `PidLockGuard` acquire
+/// discipline: a partial write (e.g. a crash mid-write) can never be
+/// observed as a corrupt `serve.json` because the rename is the only
+/// operation that makes the file visible under its final name.
+pub fn write_record(codanna_dir: &Path, record: &ServeRecord) -> DiscoveryResult<()> {
+    std::fs::create_dir_all(codanna_dir).map_err(|source| DiscoveryError::CreateDir {
+        path: codanna_dir.to_path_buf(),
+        source,
+    })?;
+
+    let final_path = record_path(codanna_dir);
+    let tmp_path = codanna_dir.join(format!("serve.json.tmp.{}", std::process::id()));
+
+    let json = serde_json::to_string(record)?;
+
+    std::fs::write(&tmp_path, json.as_bytes()).map_err(|source| DiscoveryError::Write {
+        path: tmp_path.clone(),
+        source,
+    })?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&tmp_path, std::fs::Permissions::from_mode(0o600)).map_err(
+            |source| DiscoveryError::Permissions {
+                path: tmp_path.clone(),
+                source,
+            },
+        )?;
+    }
+
+    std::fs::rename(&tmp_path, &final_path).map_err(|source| DiscoveryError::Rename {
+        from: tmp_path.clone(),
+        to: final_path.clone(),
+        source,
+    })?;
+
+    Ok(())
+}
+
+/// Read the serve discovery record from `<codanna_dir>/serve.json`.
+///
+/// Returns `None` if the file is absent, unreadable, or fails to parse
+/// (e.g. left over/corrupt from a previous crashed server) rather than
+/// erroring, since discovery is best-effort.
+pub fn read_record(codanna_dir: &Path) -> Option<ServeRecord> {
+    let contents = std::fs::read_to_string(record_path(codanna_dir)).ok()?;
+    serde_json::from_str(&contents).ok()
+}
+
+/// Remove the serve discovery record, if present. Best-effort: errors are
+/// swallowed since this is used on shutdown paths where there is nothing
+/// meaningful to do about a failed removal.
+pub fn remove_record(codanna_dir: &Path) {
+    let _ = std::fs::remove_file(record_path(codanna_dir));
+}
+
+/// Check whether a process with the given PID is currently alive.
+pub fn pid_is_alive(pid: u32) -> bool {
+    use sysinfo::{Pid, ProcessRefreshKind, ProcessesToUpdate, System};
+    let mut sys = System::new();
+    let pid = Pid::from_u32(pid);
+    sys.refresh_processes_specifics(
+        ProcessesToUpdate::Some(&[pid]),
+        true,
+        ProcessRefreshKind::nothing(),
+    );
+    sys.process(pid).is_some()
+}
+
+/// Decision produced by inspecting the current discovery record: whether an
+/// existing server can be reused as-is, or a new one must be spawned because
+/// no record exists or the recorded PID is dead.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Decision {
+    Discover,
+    Spawn,
+}
+
+/// Decide whether `record` describes a live, reusable server.
+///
+/// A `None` record (no `serve.json` yet) or a record whose PID is no longer
+/// alive (crashed/killed server, stale leftover) both resolve to `Spawn`.
+fn decide(record: Option<&ServeRecord>) -> Decision {
+    match record {
+        Some(r) if pid_is_alive(r.pid) => Decision::Discover,
+        _ => Decision::Spawn,
+    }
+}
+
+/// PID lockfile guard shared by the stdio serve lock (`.codanna/index/serve.lock`,
+/// used by `codanna serve`) and the spawn single-flight lock
+/// (`.codanna/http.lock`, used by [`discover_or_spawn`]). These are two
+/// distinct locks guarding two distinct races (one tantivy writer per index
+/// vs. one spawn attempt per workspace); they must never share a filename or
+/// a stdio serve and a proxy spawn could contend on the same lock.
+///
+/// `create_new`-first acquire: the lockfile is only ever removed after
+/// `create_new` has failed with `AlreadyExists` AND the recorded PID is
+/// verified dead. An unconditional pre-remove would delete a racing
+/// process's live lock and let two callers share one guarded resource.
+pub(crate) struct PidLockGuard {
+    path: PathBuf,
+}
+
+#[derive(Debug)]
+pub(crate) enum PidLockError {
+    /// Another process currently holds the lock (recorded PID is alive).
+    Held {
+        pid: u32,
+        lock_path: PathBuf,
+    },
+    Io(io::Error),
+}
+
+impl PidLockGuard {
+    pub(crate) fn acquire(lock_path: &Path) -> Result<Self, PidLockError> {
+        if let Some(parent) = lock_path.parent() {
+            std::fs::create_dir_all(parent).map_err(PidLockError::Io)?;
+        }
+
+        for _ in 0..3 {
+            match OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(lock_path)
+            {
+                Ok(mut f) => {
+                    f.write_all(std::process::id().to_string().as_bytes())
+                        .map_err(PidLockError::Io)?;
+                    return Ok(Self {
+                        path: lock_path.to_path_buf(),
+                    });
+                }
+                Err(e) if e.kind() == io::ErrorKind::AlreadyExists => {
+                    match read_lock_pid(lock_path) {
+                        Some(pid) if pid_is_alive(pid) => {
+                            return Err(PidLockError::Held {
+                                pid,
+                                lock_path: lock_path.to_path_buf(),
+                            });
+                        }
+                        Some(_) => {
+                            // Recorded process is dead: reclaim and retry.
+                            let _ = std::fs::remove_file(lock_path);
+                        }
+                        None => {
+                            // No parseable PID. A racing process may have
+                            // created the lock but not written its PID yet;
+                            // re-read after a grace window before treating
+                            // the file as a dead leftover (SIGKILL between
+                            // create and write leaves an empty lock that
+                            // must self-heal).
+                            std::thread::sleep(Duration::from_millis(50));
+                            match read_lock_pid(lock_path) {
+                                Some(pid) if pid_is_alive(pid) => {
+                                    return Err(PidLockError::Held {
+                                        pid,
+                                        lock_path: lock_path.to_path_buf(),
+                                    });
+                                }
+                                _ => {
+                                    let _ = std::fs::remove_file(lock_path);
+                                }
+                            }
+                        }
+                    }
+                }
+                Err(e) => return Err(PidLockError::Io(e)),
+            }
+        }
+
+        // Retries exhausted: another process keeps winning the create race.
+        let pid = read_lock_pid(lock_path).unwrap_or(0);
+        Err(PidLockError::Held {
+            pid,
+            lock_path: lock_path.to_path_buf(),
+        })
+    }
+}
+
+fn read_lock_pid(lock_path: &Path) -> Option<u32> {
+    std::fs::read_to_string(lock_path)
+        .ok()
+        .and_then(|s| s.trim().parse::<u32>().ok())
+}
+
+impl Drop for PidLockGuard {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.path);
+    }
+}
+
+/// Best-effort HTTP health probe against `127.0.0.1:{port}/health`.
+///
+/// Scheme-aware: an `Http` record is probed with a raw `TcpStream` (this
+/// module only needs to know whether *some* response comes back promptly, not
+/// to parse a body); an `Https` record is probed through
+/// [`crate::serve_tls::pinned_client`], the SAME cert-pinning client used by
+/// `mcp::proxy` -- this is deliberately not a second, hand-rolled TLS path.
+/// Any connect/read/TLS failure or non-2xx status (including the client
+/// being unavailable, e.g. `HttpsSupportNotCompiled`) is treated as "not yet
+/// healthy" rather than an error, since this is called in a poll loop where
+/// transient failures during server startup are expected.
+async fn check_health(port: u16, scheme: ServeScheme) -> bool {
+    match scheme {
+        ServeScheme::Http => {
+            let addr = format!("127.0.0.1:{port}");
+            let Ok(socket_addr) = addr.parse() else {
+                return false;
+            };
+            let Ok(mut stream) =
+                TcpStream::connect_timeout(&socket_addr, Duration::from_millis(500))
+            else {
+                return false;
+            };
+            let _ = stream.set_read_timeout(Some(Duration::from_millis(500)));
+            let _ = stream.set_write_timeout(Some(Duration::from_millis(500)));
+
+            let request = format!(
+                "GET /health HTTP/1.0\r\nHost: 127.0.0.1:{port}\r\nConnection: close\r\n\r\n"
+            );
+            if stream.write_all(request.as_bytes()).is_err() {
+                return false;
+            }
+
+            let mut buf = [0u8; 32];
+            let Ok(n) = stream.read(&mut buf) else {
+                return false;
+            };
+            let status_line = String::from_utf8_lossy(&buf[..n]);
+            status_line.starts_with("HTTP/1.0 200") || status_line.starts_with("HTTP/1.1 200")
+        }
+        ServeScheme::Https => {
+            let Ok(client) = crate::serve_tls::pinned_client() else {
+                return false;
+            };
+            let url = format!("https://127.0.0.1:{port}/health");
+            match client.get(url).send().await {
+                Ok(response) => response.status().is_success(),
+                Err(_) => false,
+            }
+        }
+    }
+}
+
+/// Poll `codanna_dir` for a discovery record whose PID is alive and whose
+/// `/health` endpoint responds, up to `timeout`. Used by both the lock
+/// winner (after spawning) and the lock loser (waiting on the winner).
+async fn wait_until_healthy(
+    codanna_dir: &Path,
+    lock_path: &Path,
+    timeout: Duration,
+    poll_interval: Duration,
+) -> DiscoveryResult<ServeRecord> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if let Some(record) = read_record(codanna_dir) {
+            if pid_is_alive(record.pid) && check_health(record.port, record.scheme).await {
+                return Ok(record);
+            }
+        }
+
+        if Instant::now() >= deadline {
+            return Err(DiscoveryError::SpawnTimeout {
+                timeout_ms: timeout.as_millis() as u64,
+                lock_path: lock_path.to_path_buf(),
+                record_path: record_path(codanna_dir),
+            });
+        }
+
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        tokio::time::sleep(poll_interval.min(remaining).max(Duration::from_millis(1))).await;
+    }
+}
+
+/// Spawn a detached `codanna serve --http --watch --bind 127.0.0.1:0` process
+/// rooted at `workspace_root`. The child's stdio is severed and it is placed
+/// in its own process group (Unix) / detached process group (Windows) so it
+/// outlives the spawning process. The caller does not wait on the child;
+/// readiness is observed exclusively through the discovery record and
+/// `/health`, matching the record+lock discipline this module relies on
+/// instead of a reaper or `ss`/`lsof`/`pgrep` process scan (deliberately
+/// dropped: record+lock alone make duplicate servers unarisable).
+fn spawn_detached(workspace_root: &Path) -> DiscoveryResult<()> {
+    let exe = std::env::current_exe().map_err(|source| DiscoveryError::CurrentExe { source })?;
+
+    let mut cmd = Command::new(exe);
+    cmd.args(["serve", "--http", "--watch", "--bind", "127.0.0.1:0"])
+        .current_dir(workspace_root)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        // Detach into its own process group so it is not killed alongside
+        // the spawning process's terminal/session.
+        cmd.process_group(0);
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        const DETACHED_PROCESS: u32 = 0x0000_0008;
+        const CREATE_NEW_PROCESS_GROUP: u32 = 0x0000_0200;
+        cmd.creation_flags(DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP);
+    }
+
+    // Intentionally not waited on: a detached server is meant to outlive
+    // this call. The handle is dropped without joining.
+    let _child = cmd.spawn().map_err(|source| DiscoveryError::Spawn {
+        workspace_root: workspace_root.to_path_buf(),
+        source,
+    })?;
+
+    Ok(())
+}
+
+/// Discover a live HTTP MCP server for `workspace_root`, spawning one if none
+/// is running.
+///
+/// 1. If `<workspace_root>/.codanna/serve.json` names a live PID, return it
+///    immediately without spawning anything.
+/// 2. Otherwise, race for a single-flight lock at
+///    `<workspace_root>/.codanna/http.lock` (create_new-first, dead-PID
+///    reclaim -- see `PidLockGuard`). The winner spawns a detached
+///    `codanna serve --http --watch --bind 127.0.0.1:0` and polls the
+///    discovery record + `/health` until it is healthy or
+///    `settings.server.spawn_timeout_ms` elapses. The loser skips spawning
+///    and polls the same way, waiting on the winner's record.
+///
+/// Spawning is guarded. A server is only ever *created* for a tree that holds a
+/// real `.codanna/settings.toml` and that has `[server] auto_spawn = true`;
+/// otherwise this returns [`DiscoveryError::NoConfiguration`] or
+/// [`DiscoveryError::AutoSpawnDisabled`]. Discovering an *already-live* server is
+/// not subject to either guard -- they gate creating a server, not using one.
+///
+/// This function never shells out to `ss`/`lsof`/`pgrep`, and there is no
+/// reaper for duplicate processes: the record file plus the O_EXCL lock make
+/// duplicate spawns structurally unarisable, so there is nothing to reap.
+///
+/// Note: exercising the real detached-spawn path end-to-end (spawning an
+/// actual `codanna serve` child and observing it become healthy) is a
+/// manual/integration validation step, not covered by the unit tests in this
+/// module.
+pub async fn discover_or_spawn(
+    workspace_root: &Path,
+    settings: &Settings,
+) -> DiscoveryResult<ServeRecord> {
+    let codanna_dir = discovery_dir(workspace_root);
+    let lock_path = codanna_dir.join("http.lock");
+    let timeout = Duration::from_millis(settings.server.spawn_timeout_ms);
+    let poll_interval = Duration::from_millis(settings.server.health_poll_ms);
+
+    // Fast path: an already-live server, no lock needed.
+    //
+    // Discovery is deliberately permissive: if a server is already serving this
+    // tree we attach to it regardless of the guards below. Those guards gate the
+    // decision to *create* a server, not the decision to *use* one.
+    if decide(read_record(&codanna_dir).as_ref()) == Decision::Discover {
+        // Safe to unwrap the option here only via re-match, not `.unwrap()`:
+        // `decide` returning `Discover` implies `Some` with a live PID.
+        if let Some(record) = read_record(&codanna_dir) {
+            return Ok(record);
+        }
+    }
+
+    // From here on the only way forward is to spawn (or to wait on a peer that
+    // is spawning). Both guards below therefore run *before* we take the lock:
+    // if this tree must never get a server, there is no point contending for the
+    // right to create one.
+    //
+    // Guard 1: never spawn into an unconfigured tree. `Settings::workspace_root`
+    // walks up for a `.codanna` *directory* and does not require the directory to
+    // hold a `settings.toml`, so a bare or leftover `.codanna/` would otherwise
+    // resolve as a workspace root and get a server (and an index) it never asked
+    // for. Require a real config before creating anything.
+    let config_path = codanna_dir.join("settings.toml");
+    if !config_path.is_file() {
+        return Err(DiscoveryError::NoConfiguration {
+            workspace_root: workspace_root.to_path_buf(),
+            config_path,
+        });
+    }
+
+    // Guard 2: honour `[server] auto_spawn`. No live server was found above, so
+    // with auto-spawn off there is nothing to attach to and nothing we may
+    // create: fail with an actionable message rather than spawning anyway.
+    if !settings.server.auto_spawn {
+        return Err(DiscoveryError::AutoSpawnDisabled {
+            workspace_root: workspace_root.to_path_buf(),
+            config_path,
+        });
+    }
+
+    match PidLockGuard::acquire(&lock_path) {
+        Ok(_guard) => {
+            // WINNER. Re-check: another process may have finished spawning
+            // between our fast-path read and winning the lock.
+            if decide(read_record(&codanna_dir).as_ref()) == Decision::Discover {
+                if let Some(record) = read_record(&codanna_dir) {
+                    return Ok(record);
+                }
+            }
+
+            spawn_detached(workspace_root)?;
+            wait_until_healthy(&codanna_dir, &lock_path, timeout, poll_interval).await
+            // `_guard` drops here, releasing the lock once the winner's
+            // spawn attempt has succeeded, timed out, or errored. Holding
+            // the guard across the `.await` above is fine: it is a file
+            // lock, not a mutex guard.
+        }
+        Err(PidLockError::Held { lock_path, .. }) => {
+            // LOSER. Someone else is spawning (or just finished); wait on
+            // their record instead of racing a second spawn.
+            wait_until_healthy(&codanna_dir, &lock_path, timeout, poll_interval).await
+        }
+        Err(PidLockError::Io(source)) => Err(DiscoveryError::LockIo {
+            path: lock_path,
+            source,
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::TcpListener;
+    use tempfile::TempDir;
+
+    #[test]
+    fn write_then_read_round_trips() {
+        let dir = TempDir::new().unwrap();
+        let record = ServeRecord {
+            pid: std::process::id(),
+            port: 8080,
+            scheme: ServeScheme::Http,
+        };
+
+        write_record(dir.path(), &record).expect("write_record should succeed");
+        let read_back = read_record(dir.path()).expect("read_record should find the record");
+
+        assert_eq!(read_back.pid, record.pid);
+        assert_eq!(read_back.port, record.port);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn written_record_has_owner_only_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = TempDir::new().unwrap();
+        let record = ServeRecord {
+            pid: std::process::id(),
+            port: 9090,
+            scheme: ServeScheme::Http,
+        };
+
+        write_record(dir.path(), &record).expect("write_record should succeed");
+
+        let path = dir.path().join("serve.json");
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "serve.json must be mode 0600");
+    }
+
+    #[test]
+    fn read_record_returns_none_when_file_is_absent() {
+        let dir = TempDir::new().unwrap();
+        assert!(read_record(dir.path()).is_none());
+    }
+
+    #[test]
+    fn read_record_returns_none_for_corrupt_file() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join("serve.json"), b"not valid json{{{").unwrap();
+        assert!(read_record(dir.path()).is_none());
+    }
+
+    #[test]
+    fn pid_zero_is_never_alive() {
+        assert!(!pid_is_alive(0));
+    }
+
+    #[tokio::test]
+    async fn discover_or_spawn_returns_live_record_without_spawning() {
+        // Given a workspace with a serve.json whose PID is *this* live test
+        // process, discover_or_spawn must return it directly. If it instead
+        // fell through to spawning, this test would hang (or fail) trying to
+        // launch a real `codanna serve` child, since `current_exe()` in a
+        // test binary is the test harness, not the CLI.
+        let workspace = TempDir::new().unwrap();
+        let codanna_dir = workspace.path().join(crate::init::local_dir_name());
+        let record = ServeRecord {
+            pid: std::process::id(),
+            port: 12345,
+            scheme: ServeScheme::Http,
+        };
+        write_record(&codanna_dir, &record).expect("write_record should succeed");
+
+        let settings = Settings::default();
+        let discovered = discover_or_spawn(workspace.path(), &settings)
+            .await
+            .expect("live record should short-circuit discovery");
+
+        assert_eq!(discovered.pid, record.pid);
+        assert_eq!(discovered.port, record.port);
+        // No lock should have been created on the fast path.
+        assert!(!codanna_dir.join("http.lock").exists());
+    }
+
+    /// A `.codanna/` directory that holds no `settings.toml` is NOT a configured
+    /// tree. `Settings::workspace_root` walks up for the *directory* only, so
+    /// without this guard a bare or leftover `.codanna/` anywhere up the tree
+    /// would silently receive a spawned server and an index it never asked for.
+    #[tokio::test]
+    async fn refuses_to_spawn_when_tree_has_no_settings_toml() {
+        let workspace = TempDir::new().unwrap();
+        let codanna_dir = workspace.path().join(crate::init::local_dir_name());
+        // A bare .codanna dir: exists, but carries no configuration.
+        std::fs::create_dir_all(&codanna_dir).unwrap();
+
+        let settings = Settings::default();
+        let err = discover_or_spawn(workspace.path(), &settings)
+            .await
+            .expect_err("an unconfigured tree must not get a spawned server");
+
+        match err {
+            DiscoveryError::NoConfiguration { config_path, .. } => {
+                assert_eq!(config_path, codanna_dir.join("settings.toml"));
+            }
+            other => panic!("expected NoConfiguration, got: {other:?}"),
+        }
+        // Nothing was created: no lock, no record.
+        assert!(!codanna_dir.join("http.lock").exists());
+        assert!(!codanna_dir.join("serve.json").exists());
+    }
+
+    /// `[server] auto_spawn = false` must actually be honoured. With no live
+    /// server to attach to there is nothing to use and nothing we may create.
+    #[tokio::test]
+    async fn refuses_to_spawn_when_auto_spawn_is_disabled() {
+        let workspace = TempDir::new().unwrap();
+        let codanna_dir = workspace.path().join(crate::init::local_dir_name());
+        std::fs::create_dir_all(&codanna_dir).unwrap();
+        // A genuinely configured tree -- so this test isolates the auto_spawn
+        // guard rather than tripping the NoConfiguration one.
+        std::fs::write(codanna_dir.join("settings.toml"), "").unwrap();
+
+        let mut settings = Settings::default();
+        settings.server.auto_spawn = false;
+
+        let err = discover_or_spawn(workspace.path(), &settings)
+            .await
+            .expect_err("auto_spawn = false must not spawn a server");
+
+        match err {
+            DiscoveryError::AutoSpawnDisabled { .. } => {}
+            other => panic!("expected AutoSpawnDisabled, got: {other:?}"),
+        }
+        assert!(!codanna_dir.join("http.lock").exists());
+    }
+
+    /// The guards gate *creating* a server, never *using* one. A live server is
+    /// attached to even when this process would not have been allowed to spawn
+    /// it (auto_spawn off, and no settings.toml on disk).
+    #[tokio::test]
+    async fn discovers_live_server_even_when_spawning_would_be_refused() {
+        let workspace = TempDir::new().unwrap();
+        let codanna_dir = workspace.path().join(crate::init::local_dir_name());
+        let record = ServeRecord {
+            pid: std::process::id(),
+            port: 12345,
+            scheme: ServeScheme::Http,
+        };
+        write_record(&codanna_dir, &record).expect("write_record should succeed");
+
+        let mut settings = Settings::default();
+        settings.server.auto_spawn = false;
+
+        let discovered = discover_or_spawn(workspace.path(), &settings)
+            .await
+            .expect("a live server must be discovered regardless of the spawn guards");
+
+        assert_eq!(discovered.pid, record.pid);
+        assert_eq!(discovered.port, record.port);
+    }
+
+    #[test]
+    fn spawn_lock_single_flight_yields_one_winner() {
+        // Two threads race to create the same lock file via create_new
+        // (O_EXCL). Exactly one must win; the other must observe Held.
+        // This is exercised directly against PidLockGuard rather than
+        // discover_or_spawn end-to-end, so the test stays hermetic and never
+        // spawns a real server process.
+        let dir = TempDir::new().unwrap();
+        let lock_path = dir.path().join("test.lock");
+
+        // A successful guard is intentionally leaked (not dropped) inside
+        // each racing thread: if the winner's guard dropped immediately
+        // after `acquire` returns, it would remove the lockfile before the
+        // losing thread's `create_new` attempt lands, letting both threads
+        // observe an empty slot and both "win" -- a timing-dependent false
+        // pass. Leaking keeps the lock held for the duration of the race;
+        // the TempDir is removed wholesale when the test ends regardless.
+        let barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
+        let lock_path_a = lock_path.clone();
+        let barrier_a = barrier.clone();
+        let handle_a = std::thread::spawn(move || {
+            barrier_a.wait();
+            match PidLockGuard::acquire(&lock_path_a) {
+                Ok(guard) => {
+                    std::mem::forget(guard);
+                    true
+                }
+                Err(_) => false,
+            }
+        });
+
+        let lock_path_b = lock_path.clone();
+        let barrier_b = barrier.clone();
+        let handle_b = std::thread::spawn(move || {
+            barrier_b.wait();
+            match PidLockGuard::acquire(&lock_path_b) {
+                Ok(guard) => {
+                    std::mem::forget(guard);
+                    true
+                }
+                Err(_) => false,
+            }
+        });
+
+        let won_a = handle_a.join().expect("thread a should not panic");
+        let won_b = handle_b.join().expect("thread b should not panic");
+
+        assert_ne!(
+            won_a, won_b,
+            "exactly one racing thread must win the single-flight lock"
+        );
+    }
+
+    #[test]
+    fn acquire_writes_pid_and_drop_removes_lock() {
+        let dir = TempDir::new().unwrap();
+        let lock_path = dir.path().join("test.lock");
+
+        {
+            let _guard = PidLockGuard::acquire(&lock_path).expect("first acquire");
+            let contents = std::fs::read_to_string(&lock_path).unwrap();
+            assert_eq!(contents.trim(), std::process::id().to_string());
+        }
+
+        assert!(
+            !lock_path.exists(),
+            "lockfile should be removed when guard drops"
+        );
+    }
+
+    /// B3: contention is signalled as `Held`, and the payload carries the
+    /// *live* PID holding the lock (not a placeholder). Before the two guards
+    /// were unified this payload was only exercised via the old
+    /// `ServeLockError::AlreadyRunning`; `PidLockError::Held` is now the single
+    /// carrier for both the stdio-serve and proxy-spawn paths.
+    #[test]
+    fn second_acquire_blocks_when_first_is_alive() {
+        let dir = TempDir::new().unwrap();
+        let lock_path = dir.path().join("test.lock");
+        let _first = PidLockGuard::acquire(&lock_path).expect("first acquire");
+
+        match PidLockGuard::acquire(&lock_path) {
+            Err(PidLockError::Held { pid, .. }) => {
+                assert_eq!(pid, std::process::id());
+            }
+            Ok(_) => panic!("second acquire should have failed"),
+            Err(other) => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unparseable_lock_is_reclaimed_after_grace_window() {
+        let dir = TempDir::new().unwrap();
+        let lock_path = dir.path().join("test.lock");
+
+        // SIGKILL between create and PID write leaves an empty lock; it must
+        // self-heal instead of blocking serve forever.
+        std::fs::write(&lock_path, "").unwrap();
+
+        let guard = PidLockGuard::acquire(&lock_path).expect("empty lock should be reclaimed");
+        let contents = std::fs::read_to_string(&lock_path).unwrap();
+        assert_eq!(contents.trim(), std::process::id().to_string());
+        drop(guard);
+        assert!(!lock_path.exists());
+    }
+
+    #[test]
+    fn stale_lock_with_dead_pid_is_overwritten() {
+        let dir = TempDir::new().unwrap();
+        let lock_path = dir.path().join("test.lock");
+
+        // PID 0 never refers to a normal process on Unix; sysinfo also
+        // reports it as absent. Use it as a synthetic stale entry.
+        std::fs::write(&lock_path, "0").unwrap();
+        assert!(!pid_is_alive(0), "PID 0 must read as dead for this test");
+
+        let guard = PidLockGuard::acquire(&lock_path).expect("stale lock should be reclaimed");
+        let contents = std::fs::read_to_string(&lock_path).unwrap();
+        assert_eq!(contents.trim(), std::process::id().to_string());
+        drop(guard);
+        assert!(!lock_path.exists());
+    }
+
+    #[test]
+    fn decide_returns_spawn_when_recorded_pid_is_dead() {
+        // PID 0 never refers to a live process on Unix and sysinfo reports
+        // it as absent too; use it as a synthetic dead/stale record.
+        let stale = ServeRecord {
+            pid: 0,
+            port: 8080,
+            scheme: ServeScheme::Http,
+        };
+        assert!(!pid_is_alive(0), "PID 0 must read as dead for this test");
+
+        assert_eq!(decide(Some(&stale)), Decision::Spawn);
+        assert_eq!(decide(None), Decision::Spawn);
+    }
+
+    #[test]
+    fn decide_returns_discover_when_recorded_pid_is_alive() {
+        let live = ServeRecord {
+            pid: std::process::id(),
+            port: 8080,
+            scheme: ServeScheme::Http,
+        };
+        assert_eq!(decide(Some(&live)), Decision::Discover);
+    }
+
+    /// THE LOAD-BEARING REGRESSION TEST.
+    ///
+    /// `discovery_dir` must be derived from `workspace_root` alone, never from
+    /// `index_path`. Before this fix, `serve --http` derived the discovery
+    /// record dir from `index_path.parent()` while `discover_or_spawn` used
+    /// `workspace_root/.codanna`; under a custom `index_path` the two
+    /// diverged, burning the proxy's spawn timeout and leaking an orphan
+    /// process. This test fails if anyone ever reintroduces an
+    /// index_path-derived discovery dir.
+    #[test]
+    fn discovery_dir_ignores_custom_index_path() {
+        let workspace = TempDir::new().unwrap();
+        // A second, unrelated tempdir stands in for a custom index_path that
+        // is NOT under `workspace/.codanna`.
+        let custom_index = TempDir::new().unwrap();
+
+        let settings = Settings {
+            workspace_root: Some(workspace.path().to_path_buf()),
+            index_path: custom_index.path().join("some-other-index"),
+            ..Settings::default()
+        };
+
+        let resolved_root = resolve_workspace_root(&settings)
+            .expect("workspace_root was explicitly set and must resolve");
+        let dir = discovery_dir(&resolved_root);
+
+        assert_eq!(
+            dir,
+            workspace.path().join(crate::init::local_dir_name()),
+            "discovery_dir must key off workspace_root, not index_path -- \
+             if this assertion fails, an index_path-derived discovery dir \
+             has been reintroduced and serve --http / discover_or_spawn will \
+             diverge again under a custom index_path"
+        );
+    }
+
+    #[test]
+    fn resolve_workspace_root_prefers_explicit_setting() {
+        // Deliberately does not rely on the CWD walk-up fallback: tests share
+        // a process CWD, so relying on that fallback here would make this
+        // test order-dependent and flaky against other tests in the suite.
+        let workspace = TempDir::new().unwrap();
+        let settings = Settings {
+            workspace_root: Some(workspace.path().to_path_buf()),
+            ..Settings::default()
+        };
+
+        assert_eq!(
+            resolve_workspace_root(&settings),
+            Some(workspace.path().to_path_buf())
+        );
+    }
+
+    /// Proves the writer (`write_record` via `discovery_dir`) and the reader
+    /// (`discover_or_spawn`'s fast path) agree on exactly one directory.
+    #[tokio::test]
+    async fn discovery_dir_matches_discover_or_spawn_fast_path() {
+        let workspace = TempDir::new().unwrap();
+        let settings = Settings {
+            workspace_root: Some(workspace.path().to_path_buf()),
+            ..Settings::default()
+        };
+
+        let resolved_root = resolve_workspace_root(&settings).unwrap();
+        let codanna_dir = discovery_dir(&resolved_root);
+
+        let record = ServeRecord {
+            pid: std::process::id(),
+            port: 12345,
+            scheme: ServeScheme::Http,
+        };
+        write_record(&codanna_dir, &record).expect("write_record should succeed");
+
+        let discovered = discover_or_spawn(workspace.path(), &settings)
+            .await
+            .expect("live record at discovery_dir(&workspace_root) should short-circuit discovery");
+
+        assert_eq!(discovered.pid, record.pid);
+        assert_eq!(discovered.port, record.port);
+        // No lock should have been created on the fast path.
+        assert!(!codanna_dir.join("http.lock").exists());
+    }
+
+    /// THE LOAD-BEARING COMPAT TEST.
+    ///
+    /// A `serve.json` written before `scheme` existed carries no `scheme`
+    /// key at all. `#[serde(default)]` must let this still parse (as
+    /// `ServeScheme::Http`); if it instead failed to parse, `read_record`
+    /// would silently return `None`, `decide` would resolve to `Spawn`, and
+    /// a live server left over from before an upgrade would get a duplicate
+    /// spawned alongside it.
+    #[test]
+    fn legacy_record_without_scheme_reads_as_http() {
+        let dir = TempDir::new().unwrap();
+        let pid = std::process::id();
+        std::fs::write(
+            dir.path().join("serve.json"),
+            format!(r#"{{"pid":{pid},"port":8080}}"#),
+        )
+        .unwrap();
+
+        let record = read_record(dir.path());
+        assert!(
+            record.is_some(),
+            "a legacy serve.json without a scheme key must still parse; \
+             otherwise read_record returns None, decide() resolves to Spawn, \
+             and a duplicate server gets spawned alongside the live legacy one"
+        );
+        assert_eq!(record.unwrap().scheme, ServeScheme::Http);
+    }
+
+    #[test]
+    fn https_record_round_trips() {
+        let dir = TempDir::new().unwrap();
+        let record = ServeRecord {
+            pid: std::process::id(),
+            port: 8443,
+            scheme: ServeScheme::Https,
+        };
+
+        write_record(dir.path(), &record).expect("write_record should succeed");
+
+        let raw = std::fs::read_to_string(dir.path().join("serve.json")).unwrap();
+        assert!(
+            raw.contains(r#""scheme":"https""#),
+            "on-disk JSON must literally contain the lowercase scheme value, got: {raw}"
+        );
+
+        let read_back = read_record(dir.path()).expect("read_record should find the record");
+        assert_eq!(read_back.scheme, ServeScheme::Https);
+    }
+
+    /// THE ANTI-RELOCATION CHECK.
+    ///
+    /// Probing a plaintext listener through the `Https` arm must never report
+    /// healthy -- whether because there is no persisted cert to pin
+    /// (`pinned_client` fails closed) or, when one is present, because the
+    /// TLS handshake itself fails against a plaintext peer. This guards
+    /// against a future change accidentally treating a bare TCP response (or
+    /// a connection error swallowed the wrong way) as a valid HTTPS health
+    /// check.
+    #[tokio::test]
+    async fn https_health_probe_rejects_plaintext_listener() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+
+        // The listener must serve a genuine plaintext 200 -- the same shape
+        // `http_health_probe_still_succeeds` relies on. A listener that merely
+        // accepted and dropped the connection would make this test vacuous:
+        // the plaintext probe would report unhealthy against it too, so the
+        // assertion below would hold even if the `Https` arm were wired back
+        // to the plaintext probe. Answering 200 is what gives it teeth -- the
+        // plaintext probe reports *healthy* here, so only a real TLS handshake
+        // (which a plaintext peer cannot complete) yields the expected `false`.
+        std::thread::spawn(move || {
+            for stream in listener.incoming().flatten() {
+                let mut stream = stream;
+                let mut buf = [0u8; 512];
+                let _ = stream.read(&mut buf);
+                let _ = stream.write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n");
+            }
+        });
+
+        assert!(!check_health(port, ServeScheme::Https).await);
+    }
+
+    /// Guards the untouched `Http` arm: a trivial plaintext 200 response
+    /// must still be recognized as healthy after the scheme-aware,
+    /// async conversion.
+    #[tokio::test]
+    async fn http_health_probe_still_succeeds() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+
+        std::thread::spawn(move || {
+            if let Ok((mut stream, _)) = listener.accept() {
+                let mut buf = [0u8; 512];
+                let _ = stream.read(&mut buf);
+                let _ = stream.write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n");
+            }
+        });
+
+        assert!(check_health(port, ServeScheme::Http).await);
+    }
+}

--- a/src/serve_tls.rs
+++ b/src/serve_tls.rs
@@ -1,0 +1,206 @@
+//! Single source of truth for the persisted self-signed TLS cert/key paths,
+//! and for the ONE cert-pinning HTTP client used to dial a `--https` backing
+//! MCP server.
+//!
+//! This lives at crate root, not under `src/mcp/`: it is consumed by
+//! [`crate::serve_discovery`] (root, for the `/health` probe against an
+//! `--https` backing server) and by `mcp::proxy` / `mcp::https_server`
+//! (subsystem). Nesting it inside either subsystem's directory would force
+//! the other subsystem to depend on it through an unrelated module, which
+//! is exactly the layering violation this module is meant to avoid.
+//!
+//! # Cert trust
+//!
+//! [`pinned_client`] pins the persisted server certificate via
+//! [`reqwest::ClientBuilder::tls_certs_only`]: only that one certificate is
+//! trusted, system/native roots are excluded entirely, and there is no
+//! verification bypass on any error path. This is deliberate and
+//! non-negotiable -- do not replace `tls_certs_only` with
+//! `add_root_certificate` (deprecated, merges with native roots) or with any
+//! `danger_accept_invalid_certs`-style escape hatch.
+
+use std::path::PathBuf;
+
+use thiserror::Error;
+
+/// Absolute paths to the persisted self-signed server cert and key.
+///
+/// This is the SINGLE definition of
+/// `dirs::config_dir()/codanna/certs/{server.pem,server.key}`. Both the
+/// writer (`mcp::https_server::get_or_create_certificate`, which generates
+/// and persists the cert/key) and every reader (this module's
+/// [`pinned_client`]) go through this function rather than recomputing the
+/// join; otherwise the writer and a reader can silently drift onto different
+/// files and the pin would point at the wrong certificate.
+///
+/// Returns `None` if the platform config directory cannot be determined
+/// (mirrors [`dirs::config_dir`]'s own `None` case, e.g. no
+/// `HOME`/`XDG_CONFIG_HOME` on Unix).
+pub fn cert_paths() -> Option<(PathBuf, PathBuf)> {
+    let cert_dir = dirs::config_dir()?.join("codanna").join("certs");
+    Some((cert_dir.join("server.pem"), cert_dir.join("server.key")))
+}
+
+/// Errors constructing the cert-pinning client used to dial a `--https`
+/// backing MCP server.
+#[derive(Debug, Error)]
+pub enum TlsClientError {
+    #[error(
+        "persisted server certificate not found at '{path}'; start the backing server at least once with 'codanna serve --https' so it generates and persists a self-signed certificate before a client can pin it"
+    )]
+    CertNotFound { path: PathBuf },
+
+    #[error("failed to read persisted server certificate '{path}': {source}")]
+    CertRead {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+
+    #[error(
+        "failed to parse persisted server certificate '{path}' as PEM: {source}; delete the certs directory and restart 'codanna serve --https' to regenerate it"
+    )]
+    CertParse {
+        path: PathBuf,
+        #[source]
+        source: rmcp_reqwest::Error,
+    },
+
+    #[error("failed to build the cert-pinned HTTPS client: {source}")]
+    ClientBuild {
+        #[source]
+        source: rmcp_reqwest::Error,
+    },
+
+    #[error(
+        "codanna was built without the 'https-server' feature; rebuild with --features https-server to dial a '--https' backing server"
+    )]
+    HttpsSupportNotCompiled,
+}
+
+/// Result alias for this module's fallible operations (§RS.3).
+pub type TlsResult<T> = Result<T, TlsClientError>;
+
+/// One-time, idempotent install of the `ring` rustls crypto provider as the
+/// process default.
+///
+/// `reqwest`'s `rustls-no-provider` backend (the one this module uses via
+/// [`pinned_client`]) requires a default [`rustls::crypto::CryptoProvider`]
+/// to already be installed before the FIRST `rmcp_reqwest::Client` is built
+/// anywhere in the process, or that build panics. This crate already pins
+/// the shared `rustls` dependency to the `ring` backend only (see the
+/// `[features].https-server` comment in `Cargo.toml`), so installing `ring`
+/// here is consistent with, not additional to, that existing pin.
+/// `install_default` failing (a provider is already installed, e.g. by the
+/// HTTPS server binding via `axum-server`) is expected and ignored: either
+/// provider being `ring` is equally correct for this process.
+#[cfg(feature = "https-server")]
+fn ensure_crypto_provider_installed() {
+    static INIT: std::sync::Once = std::sync::Once::new();
+    INIT.call_once(|| {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+    });
+}
+
+/// The ONE TLS-trusting client used to dial a `--https` backing server.
+///
+/// Used by [`crate::serve_discovery`]'s `/health` probe and by `mcp::proxy`
+/// (as the `rmcp` `StreamableHttpClient`). Trust is `tls_certs_only([persisted
+/// cert])`: no system roots, no verification bypass.
+///
+/// Pool/redirect settings mirror `rmcp`'s own
+/// `StreamableHttpClientTransport::default_http_client`: `pool_max_idle_per_host(0)`
+/// avoids a ~40ms stall from TCP Delayed ACK when a streamed SSE response body
+/// was not fully consumed before the pool tries to reuse the connection, and
+/// `redirect::Policy::none()` stops a redirect target from replaying
+/// caller-supplied custom headers (e.g. the bearer token). Dropping either
+/// silently changes transport behavior, not just decoration.
+#[cfg(feature = "https-server")]
+pub fn pinned_client() -> TlsResult<rmcp_reqwest::Client> {
+    let (cert_path, _key_path) = cert_paths().ok_or_else(|| TlsClientError::CertNotFound {
+        path: PathBuf::from("<unresolvable config directory>/codanna/certs/server.pem"),
+    })?;
+
+    if !cert_path.is_file() {
+        return Err(TlsClientError::CertNotFound { path: cert_path });
+    }
+
+    let pem = std::fs::read(&cert_path).map_err(|source| TlsClientError::CertRead {
+        path: cert_path.clone(),
+        source,
+    })?;
+
+    let cert =
+        rmcp_reqwest::Certificate::from_pem(&pem).map_err(|source| TlsClientError::CertParse {
+            path: cert_path.clone(),
+            source,
+        })?;
+
+    ensure_crypto_provider_installed();
+
+    rmcp_reqwest::Client::builder()
+        .tls_certs_only([cert])
+        .pool_max_idle_per_host(0)
+        .redirect(rmcp_reqwest::redirect::Policy::none())
+        .build()
+        .map_err(|source| TlsClientError::ClientBuild { source })
+}
+
+/// Without the `https-server` feature there is no TLS backend compiled into
+/// the pinned client's `reqwest` dependency, so a `--https` backing server
+/// can never be dialed from this build.
+#[cfg(not(feature = "https-server"))]
+pub fn pinned_client() -> TlsResult<rmcp_reqwest::Client> {
+    Err(TlsClientError::HttpsSupportNotCompiled)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    /// On Linux, `dirs::config_dir()` prefers `XDG_CONFIG_HOME` over
+    /// `HOME/.config`. Overriding only `HOME` does not isolate this test from
+    /// whatever `XDG_CONFIG_HOME` is already set to in the ambient
+    /// environment (e.g. a real persisted cert from a developer's own
+    /// `codanna serve --https` run), so both must be pointed at the temp dir.
+    #[test]
+    fn pinned_client_errors_when_cert_absent() {
+        let temp_dir = TempDir::new().expect("failed to create temp dir");
+
+        let original_home = std::env::var("HOME").ok();
+        let original_xdg_config_home = std::env::var("XDG_CONFIG_HOME").ok();
+        unsafe {
+            std::env::set_var("HOME", temp_dir.path());
+            std::env::set_var("XDG_CONFIG_HOME", temp_dir.path().join(".config"));
+        }
+
+        let result = pinned_client();
+
+        unsafe {
+            match original_home {
+                Some(home) => std::env::set_var("HOME", home),
+                None => std::env::remove_var("HOME"),
+            }
+            match original_xdg_config_home {
+                Some(xdg) => std::env::set_var("XDG_CONFIG_HOME", xdg),
+                None => std::env::remove_var("XDG_CONFIG_HOME"),
+            }
+        }
+
+        match result {
+            #[cfg(feature = "https-server")]
+            Err(TlsClientError::CertNotFound { path }) => {
+                let rendered = TlsClientError::CertNotFound { path: path.clone() }.to_string();
+                assert!(
+                    rendered.contains(&path.display().to_string()),
+                    "rendered CertNotFound message must contain the cert path, got: {rendered}"
+                );
+            }
+            #[cfg(not(feature = "https-server"))]
+            Err(TlsClientError::HttpsSupportNotCompiled) => {}
+            other => panic!(
+                "expected CertNotFound (https-server) or HttpsSupportNotCompiled (no https-server), got: {other:?}"
+            ),
+        }
+    }
+}

--- a/tests/cli/support.rs
+++ b/tests/cli/support.rs
@@ -1,0 +1,56 @@
+use std::env;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+pub fn codanna_binary() -> PathBuf {
+    if let Some(path) = option_env!("CARGO_BIN_EXE_codanna") {
+        return PathBuf::from(path);
+    }
+
+    if let Ok(path) = env::var("CODANNA_BIN") {
+        let bin = PathBuf::from(path);
+        if bin.exists() {
+            return bin;
+        }
+    }
+
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| env::current_dir().expect("current dir"));
+
+    let debug_bin = if cfg!(windows) {
+        manifest_dir.join("target/debug/codanna.exe")
+    } else {
+        manifest_dir.join("target/debug/codanna")
+    };
+    if debug_bin.exists() {
+        return debug_bin;
+    }
+
+    let status = Command::new("cargo")
+        .args(["build", "--bin", "codanna"])
+        .current_dir(&manifest_dir)
+        .status()
+        .expect("build codanna binary");
+    assert!(status.success(), "cargo build failed");
+    debug_bin
+}
+
+pub fn run_cli(workspace: &Path, args: &[&str]) -> (i32, String, String) {
+    let bin = codanna_binary();
+    let test_home = workspace.join(".home");
+    std::fs::create_dir_all(&test_home).expect("create test home");
+
+    let output = Command::new(&bin)
+        .args(args)
+        .current_dir(workspace)
+        .env("HOME", &test_home)
+        .output()
+        .expect("run codanna CLI");
+
+    (
+        output.status.code().unwrap_or(-1),
+        String::from_utf8_lossy(&output.stdout).to_string(),
+        String::from_utf8_lossy(&output.stderr).to_string(),
+    )
+}

--- a/tests/cli/test_mcp_index_info_remote_status.rs
+++ b/tests/cli/test_mcp_index_info_remote_status.rs
@@ -1,12 +1,12 @@
 use serde_json::{Value, json};
-use std::env;
 use std::io::{Read, Write};
 use std::net::TcpListener;
-use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::path::Path;
 use std::thread;
 
 use tempfile::TempDir;
+
+use crate::support::run_cli;
 
 fn spawn_embedding_server(max_requests: usize, dimension: usize) -> String {
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind test server");
@@ -84,59 +84,6 @@ fn spawn_embedding_server(max_requests: usize, dimension: usize) -> String {
     });
 
     format!("http://{addr}")
-}
-
-fn codanna_binary() -> PathBuf {
-    if let Some(path) = option_env!("CARGO_BIN_EXE_codanna") {
-        return PathBuf::from(path);
-    }
-
-    if let Ok(path) = env::var("CODANNA_BIN") {
-        let bin = PathBuf::from(path);
-        if bin.exists() {
-            return bin;
-        }
-    }
-
-    let manifest_dir = env::var("CARGO_MANIFEST_DIR")
-        .map(PathBuf::from)
-        .unwrap_or_else(|_| env::current_dir().expect("current dir"));
-
-    let debug_bin = if cfg!(windows) {
-        manifest_dir.join("target/debug/codanna.exe")
-    } else {
-        manifest_dir.join("target/debug/codanna")
-    };
-    if debug_bin.exists() {
-        return debug_bin;
-    }
-
-    let status = Command::new("cargo")
-        .args(["build", "--bin", "codanna"])
-        .current_dir(&manifest_dir)
-        .status()
-        .expect("build codanna binary");
-    assert!(status.success(), "cargo build failed");
-    debug_bin
-}
-
-fn run_cli(workspace: &Path, args: &[&str]) -> (i32, String, String) {
-    let bin = codanna_binary();
-    let test_home = workspace.join(".home");
-    std::fs::create_dir_all(&test_home).expect("create test home");
-
-    let output = Command::new(&bin)
-        .args(args)
-        .current_dir(workspace)
-        .env("HOME", &test_home)
-        .output()
-        .expect("run codanna CLI");
-
-    (
-        output.status.code().unwrap_or(-1),
-        String::from_utf8_lossy(&output.stdout).to_string(),
-        String::from_utf8_lossy(&output.stderr).to_string(),
-    )
 }
 
 fn write_fixture_source(src_dir: &Path) {

--- a/tests/cli/test_plugin_commands.rs
+++ b/tests/cli/test_plugin_commands.rs
@@ -1,8 +1,9 @@
-use std::env;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::process::Command;
 
 use tempfile::TempDir;
+
+use crate::support::run_cli;
 
 fn with_temp_workspace<F>(test: F)
 where
@@ -85,57 +86,6 @@ fn create_marketplace_repo(workspace: &Path, plugin_name: &str) -> String {
     run(&["commit", "-m", "initial commit"]);
 
     repo_path.to_str().unwrap().to_string()
-}
-
-fn codanna_binary() -> PathBuf {
-    if let Some(path) = option_env!("CARGO_BIN_EXE_codanna") {
-        return PathBuf::from(path);
-    }
-
-    if let Ok(path) = env::var("CODANNA_BIN") {
-        let bin = PathBuf::from(path);
-        if bin.exists() {
-            return bin;
-        }
-    }
-
-    let manifest_dir = env::var("CARGO_MANIFEST_DIR")
-        .map(PathBuf::from)
-        .unwrap_or_else(|_| env::current_dir().expect("current dir"));
-
-    let debug_bin = manifest_dir.join("target/debug/codanna");
-    if debug_bin.exists() {
-        return debug_bin;
-    }
-
-    let status = Command::new("cargo")
-        .args(["build", "--bin", "codanna"])
-        .current_dir(&manifest_dir)
-        .status()
-        .expect("build codanna binary");
-    assert!(status.success(), "cargo build failed");
-    debug_bin
-}
-
-fn run_cli(workspace: &Path, args: &[&str]) -> (i32, String, String) {
-    let bin = codanna_binary();
-    let test_home = dirs::home_dir()
-        .unwrap_or_else(|| PathBuf::from("/tmp"))
-        .join(".codanna-test");
-    std::fs::create_dir_all(&test_home).expect("create test home directory");
-
-    let output = Command::new(&bin)
-        .args(args)
-        .current_dir(workspace)
-        .env("HOME", &test_home)
-        .output()
-        .expect("run codanna CLI");
-
-    let code = output.status.code().unwrap_or(-1);
-    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
-    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-
-    (code, stdout, stderr)
 }
 
 #[test]

--- a/tests/cli/test_serve_proxy_discovery.rs
+++ b/tests/cli/test_serve_proxy_discovery.rs
@@ -1,0 +1,1009 @@
+//! Real-process end-to-end coverage for `codanna serve --proxy` discovery.
+//!
+//! Unlike the hermetic two-thread race test in `serve_discovery.rs`'s own
+//! `#[cfg(test)]` module, these tests drive the actual `codanna` binary as a
+//! subprocess: `discover_or_spawn` resolves its child via
+//! `std::env::current_exe()`, which inside a test *binary* resolves to the
+//! test harness rather than `codanna` -- so the real spawn path can only be
+//! exercised by making `codanna` itself the process that calls it. Running
+//! two `codanna serve --proxy` children against one temp workspace exercises
+//! two concurrent, cross-process `discover_or_spawn` calls, racing on the
+//! `.codanna/http.lock` `O_EXCL` file -- a strictly stronger check than an
+//! in-process, two-thread race.
+
+use std::ffi::OsStr;
+use std::io::{BufRead, BufReader};
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::sync::mpsc;
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::Duration;
+
+use sysinfo::{Pid, ProcessRefreshKind, ProcessesToUpdate, System, UpdateKind};
+use tempfile::TempDir;
+
+use crate::support::{codanna_binary, run_cli};
+
+/// Upper bound for every blocking wait in this file so a stuck proxy or
+/// backing server FAILS the test instead of hanging CI.
+const DEADLINE: Duration = Duration::from_secs(30);
+
+/// Build a workspace with a uniquely-named fixture symbol, semantic search
+/// disabled (see module docs on the KNOWN RISK below), and an already-built
+/// index, ready for `codanna serve --proxy` to discover/spawn against.
+///
+/// KNOWN RISK verified before writing these tests: `Commands::Serve { .. }`
+/// in non-proxy mode forces `needs_semantic_search = true` in `main.rs`, so
+/// the spawned `serve --http` child takes the `load_facade` (not
+/// `load_facade_lite`) path. However, `enable_semantic_search` and the
+/// eager-load-if-present path in `IndexPersistence::load_facade_impl` are
+/// additionally gated on `config.semantic_search.enabled` and on persisted
+/// semantic data existing on disk, respectively. With `enabled = false` at
+/// index time, no semantic data is ever persisted, so the spawned child does
+/// not load a model on either indexing or serve.
+fn prepare_workspace() -> TempDir {
+    let workspace = TempDir::new().expect("create temp workspace");
+
+    let src_dir = workspace.path().join("src");
+    std::fs::create_dir_all(&src_dir).expect("create src dir");
+    std::fs::write(
+        src_dir.join("lib.rs"),
+        r#"
+/// Unique marker symbol used only by the serve --proxy discovery e2e tests.
+pub fn codanna_proxy_e2e_marker() -> i32 {
+    42
+}
+"#,
+    )
+    .expect("write fixture source");
+
+    let codanna_dir = workspace.path().join(".codanna");
+    std::fs::create_dir_all(&codanna_dir).expect("create .codanna dir");
+    std::fs::write(
+        codanna_dir.join("settings.toml"),
+        r#"
+index_path = ".codanna/index"
+
+[semantic_search]
+enabled = false
+"#,
+    )
+    .expect("write settings.toml");
+
+    let (code, stdout, stderr) = run_cli(
+        workspace.path(),
+        &["index", "src", "--force", "--no-progress"],
+    );
+    assert_eq!(
+        code, 0,
+        "workspace fixture index should succeed\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+
+    workspace
+}
+
+/// Build a workspace configured with a NON-DEFAULT, absolute `index_path`
+/// pointing OUTSIDE `<workspace>/.codanna/`, in a second, unrelated tempdir.
+///
+/// Every other fixture in this file uses the default `index_path`, where
+/// `index_path.parent()` and `<workspace_root>/.codanna` happen to be the
+/// same directory -- exactly why the bug this file's tests guard against
+/// shipped unnoticed. `init::resolve_index_path` returns an absolute
+/// `index_path` as-is (see `src/init.rs`), so this is a genuinely supported
+/// configuration a real user could write, not a synthetic corner case.
+///
+/// Returns `(workspace, index_container)`: the workspace tempdir, and the
+/// second tempdir holding the custom index, so callers can assert nothing
+/// under the latter ever receives a discovery record.
+fn prepare_custom_index_path_workspace() -> (TempDir, TempDir) {
+    let workspace = TempDir::new().expect("create temp workspace");
+    let index_container = TempDir::new().expect("create temp index container");
+
+    let src_dir = workspace.path().join("src");
+    std::fs::create_dir_all(&src_dir).expect("create src dir");
+    std::fs::write(
+        src_dir.join("lib.rs"),
+        r#"
+/// Unique marker symbol used only by the custom index_path proxy discovery
+/// e2e test.
+pub fn codanna_proxy_e2e_custom_index_marker() -> i32 {
+    99
+}
+"#,
+    )
+    .expect("write fixture source");
+
+    let codanna_dir = workspace.path().join(".codanna");
+    std::fs::create_dir_all(&codanna_dir).expect("create .codanna dir");
+
+    let custom_index_path = index_container.path().join("custom-index");
+    std::fs::write(
+        codanna_dir.join("settings.toml"),
+        format!(
+            r#"
+index_path = {custom_index_path:?}
+
+[semantic_search]
+enabled = false
+"#,
+        ),
+    )
+    .expect("write settings.toml");
+
+    let (code, stdout, stderr) = run_cli(
+        workspace.path(),
+        &["index", "src", "--force", "--no-progress"],
+    );
+    assert_eq!(
+        code, 0,
+        "workspace fixture index (custom index_path) should succeed\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        custom_index_path.exists(),
+        "index should have been written to the custom index_path, not the default location"
+    );
+
+    (workspace, index_container)
+}
+
+/// Start `codanna serve --proxy` rooted at `ws`. stdin is left piped and
+/// open: `.output()` would close stdin immediately, and the stdio proxy
+/// transport exits as soon as it observes stdin EOF.
+fn start_proxy(ws: &Path) -> Child {
+    let test_home = ws.join(".home");
+    std::fs::create_dir_all(&test_home).expect("create test home");
+
+    Command::new(codanna_binary())
+        .args(["serve", "--proxy"])
+        .current_dir(ws)
+        // `XDG_CONFIG_HOME` is set alongside `HOME` (to the SAME per-test
+        // dir) because `dirs::config_dir()` -- used by both
+        // `serve_tls::pinned_client` (here, to pin the backing HTTPS
+        // server's cert) and `get_or_create_certificate` (there, to persist
+        // it) -- prefers an ambient `XDG_CONFIG_HOME` over `HOME` on Linux.
+        // Leaving it unset would let a real ambient `XDG_CONFIG_HOME` on the
+        // test runner point this process at a different (real user)
+        // certs directory than the one the test's own `--https` child wrote
+        // to, silently breaking the HTTPS discovery tests below.
+        .env("HOME", &test_home)
+        .env("XDG_CONFIG_HOME", &test_home)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn codanna serve --proxy")
+}
+
+/// Parse `Proxy: delegating to backing HTTP server at 127.0.0.1:{port} (pid
+/// {pid})` (see `src/mcp/proxy.rs`'s `serve_proxy`) out of one stderr line.
+fn parse_delegating_line(line: &str) -> Option<(u32, u16)> {
+    let after_addr = line.split("127.0.0.1:").nth(1)?;
+    let port: u16 = after_addr
+        .chars()
+        .take_while(|c| c.is_ascii_digit())
+        .collect::<String>()
+        .parse()
+        .ok()?;
+
+    let after_pid = line.split("(pid ").nth(1)?;
+    let pid: u32 = after_pid
+        .chars()
+        .take_while(|c| c.is_ascii_digit())
+        .collect::<String>()
+        .parse()
+        .ok()?;
+
+    Some((pid, port))
+}
+
+/// Block (deadline-bounded) until `child`'s stderr prints the delegation
+/// line, returning the backing server's `(pid, port)`.
+fn await_upstream(child: &mut Child) -> (u32, u16) {
+    let stderr = child
+        .stderr
+        .take()
+        .expect("proxy child stderr should be piped");
+
+    let (tx, rx) = mpsc::channel();
+    thread::spawn(move || {
+        let reader = BufReader::new(stderr);
+        for line in reader.lines() {
+            let Ok(line) = line else { break };
+            if let Some(found) = parse_delegating_line(&line) {
+                let _ = tx.send(found);
+                return;
+            }
+        }
+    });
+
+    rx.recv_timeout(DEADLINE)
+        .expect("proxy should report the backing HTTP server within the deadline")
+}
+
+/// Like [`await_upstream`], but also returns the raw delegation line so
+/// callers can assert on its dial-scheme prefix (e.g. `https://`).
+#[cfg(feature = "https-server")]
+fn await_upstream_with_line(child: &mut Child) -> (u32, u16, String) {
+    let stderr = child
+        .stderr
+        .take()
+        .expect("proxy child stderr should be piped");
+
+    let (tx, rx) = mpsc::channel();
+    thread::spawn(move || {
+        let reader = BufReader::new(stderr);
+        for line in reader.lines() {
+            let Ok(line) = line else { break };
+            if let Some((pid, port)) = parse_delegating_line(&line) {
+                let _ = tx.send((pid, port, line));
+                return;
+            }
+        }
+    });
+
+    rx.recv_timeout(DEADLINE)
+        .expect("proxy should report the backing server within the deadline")
+}
+
+/// Start `codanna serve --https --bind 127.0.0.1:0` rooted at `ws`, with
+/// `HOME`/`XDG_CONFIG_HOME` set to the SAME per-test dir `start_proxy` uses,
+/// so the proxy's `serve_tls::pinned_client` pins the exact cert this
+/// process persists.
+#[cfg(feature = "https-server")]
+fn start_https_server(ws: &Path) -> Child {
+    let test_home = ws.join(".home");
+    std::fs::create_dir_all(&test_home).expect("create test home");
+
+    Command::new(codanna_binary())
+        .args(["serve", "--https", "--bind", "127.0.0.1:0"])
+        .current_dir(ws)
+        .env("HOME", &test_home)
+        .env("XDG_CONFIG_HOME", &test_home)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn codanna serve --https")
+}
+
+/// Deadline-bounded wait for `<ws>/.codanna/serve.json` to exist and name an
+/// `Https` backing server, returning the converged record.
+#[cfg(feature = "https-server")]
+fn wait_for_https_record(ws: &Path) -> codanna::serve_discovery::ServeRecord {
+    let codanna_dir = ws.join(".codanna");
+    wait_until(
+        || {
+            codanna::serve_discovery::read_record(&codanna_dir)
+                .map(|record| record.scheme == codanna::serve_discovery::ServeScheme::Https)
+                .unwrap_or(false)
+        },
+        DEADLINE,
+        "serve.json to record an Https backing server",
+    );
+    codanna::serve_discovery::read_record(&codanna_dir)
+        .expect("serve.json should exist once the Https record has converged")
+}
+
+/// Absolute path to the persisted server cert under the per-test config dir
+/// (`XDG_CONFIG_HOME` = `HOME` = `<ws>/.home`, matching [`start_https_server`]
+/// and [`start_proxy`]).
+#[cfg(feature = "https-server")]
+fn test_server_cert_path(ws: &Path) -> PathBuf {
+    ws.join(".home")
+        .join("codanna")
+        .join("certs")
+        .join("server.pem")
+}
+
+/// Count live processes whose cwd is `ws` (canonicalized) and whose command
+/// line contains both `serve` and `--http`. cwd is the only discriminator
+/// available: `spawn_detached` (`serve_discovery.rs`) sets `current_dir` on
+/// the child and passes no workspace path argument.
+fn count_http_children(ws: &Path) -> usize {
+    let canonical_root = ws.canonicalize().expect("canonicalize workspace root");
+
+    let mut sys = System::new();
+    let refresh_kind = ProcessRefreshKind::nothing()
+        .with_cwd(UpdateKind::Always)
+        .with_cmd(UpdateKind::Always);
+    sys.refresh_processes_specifics(ProcessesToUpdate::All, true, refresh_kind);
+
+    sys.processes()
+        .values()
+        // On Linux, sysinfo also enumerates each thread of a multi-threaded
+        // process (e.g. every tokio worker thread of `serve --http`) as its
+        // own `Process` entry sharing the parent's cwd and cmd line.
+        // `thread_kind()` is `Some` only for those thread entries, so
+        // filtering them out is required to count actual OS processes
+        // rather than (cwd, cmd)-matching threads.
+        .filter(|process| process.thread_kind().is_none())
+        .filter(|process| {
+            process.cwd() == Some(canonical_root.as_path())
+                && process.cmd().iter().any(|arg| arg == OsStr::new("serve"))
+                && process.cmd().iter().any(|arg| arg == OsStr::new("--http"))
+        })
+        .count()
+}
+
+/// Best-effort SIGKILL of `pid` via sysinfo, used both to simulate a crashed
+/// backing server and to reap it at test teardown.
+fn kill_pid(pid: u32) {
+    let target = Pid::from_u32(pid);
+    let mut sys = System::new();
+    sys.refresh_processes_specifics(
+        ProcessesToUpdate::Some(&[target]),
+        true,
+        ProcessRefreshKind::nothing(),
+    );
+    if let Some(process) = sys.process(target) {
+        let _ = process.kill();
+    }
+}
+
+/// Send SIGINT (not SIGKILL) to `pid`, used to trigger the backing server's
+/// `shutdown_signal` future (`ctrl_c()` in `src/mcp/http_server.rs`) so its
+/// graceful-shutdown `remove_record` cleanup path actually runs, instead of
+/// being reaped abruptly.
+fn interrupt_pid(pid: u32) {
+    let target = Pid::from_u32(pid);
+    let mut sys = System::new();
+    sys.refresh_processes_specifics(
+        ProcessesToUpdate::Some(&[target]),
+        true,
+        ProcessRefreshKind::nothing(),
+    );
+    if let Some(process) = sys.process(target) {
+        let _ = process.kill_with(sysinfo::Signal::Interrupt);
+    }
+}
+
+/// Recursively check whether any file named `filename` exists anywhere under
+/// `root` (including nested directories). Used to confirm no shadow
+/// discovery record leaks under a custom `index_path`'s directory tree.
+fn any_file_named(root: &Path, filename: &str) -> bool {
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                stack.push(path);
+            } else if path.file_name() == Some(OsStr::new(filename)) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// Deadline-bounded wait that distinguishes a child which terminated *on its
+/// own* from one the harness had to SIGKILL: returns `None` when the deadline
+/// elapsed with the child still running (it is killed and reaped either way,
+/// so no process leaks).
+///
+/// This distinction is load-bearing for fail-closed assertions. A SIGKILLed
+/// child also reports a non-success exit status, so `!status.success()` alone
+/// cannot tell "the process refused to proceed" apart from "the process was
+/// working fine and we killed it".
+fn wait_for_self_exit(child: &mut Child, deadline: Duration) -> Option<std::process::ExitStatus> {
+    let start = std::time::Instant::now();
+    loop {
+        if let Some(status) = child.try_wait().expect("poll proxy child exit status") {
+            return Some(status);
+        }
+        if start.elapsed() >= deadline {
+            let _ = child.kill();
+            let _ = child.wait();
+            return None;
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+}
+
+/// Deadline-bounded poll: panics rather than hanging if `predicate` never
+/// becomes true within `deadline`.
+fn wait_until(mut predicate: impl FnMut() -> bool, deadline: Duration, what: &str) {
+    let start = std::time::Instant::now();
+    loop {
+        if predicate() {
+            return;
+        }
+        assert!(start.elapsed() < deadline, "timed out waiting for: {what}");
+        thread::sleep(Duration::from_millis(100));
+    }
+}
+
+/// Kills the backing `serve --http` process recorded in
+/// `<workspace>/.codanna/serve.json`, if any, when dropped. Mandatory on
+/// every test in this file: without it, a failing test leaks a detached
+/// `serve --http` process that outlives the test run.
+struct Reaper(PathBuf);
+
+impl Drop for Reaper {
+    fn drop(&mut self) {
+        let codanna_dir = self.0.join(".codanna");
+        if let Some(record) = codanna::serve_discovery::read_record(&codanna_dir) {
+            kill_pid(record.pid);
+        }
+    }
+}
+
+#[test]
+fn two_concurrent_proxies_share_one_backing_http_server() {
+    let workspace = prepare_workspace();
+    // Declared before any proxies are started so it drops (and reaps the
+    // backing server) after every other local in this test, regardless of
+    // which assertion fails first.
+    let _reaper = Reaper(workspace.path().to_path_buf());
+
+    // Start both proxies back-to-back, before either can converge: no
+    // serve.json record exists yet, so both take the lock-acquisition path.
+    let mut proxy_a = start_proxy(workspace.path());
+    let mut proxy_b = start_proxy(workspace.path());
+
+    let (pid_a, port_a) = await_upstream(&mut proxy_a);
+    let (pid_b, port_b) = await_upstream(&mut proxy_b);
+
+    let _ = proxy_a.kill();
+    let _ = proxy_a.wait();
+    let _ = proxy_b.kill();
+    let _ = proxy_b.wait();
+
+    // A1: both proxies must report the same backing server -- kills "loser
+    // waits on the wrong record" (mismatched pid/port, or a loser
+    // SpawnTimeout because it never observed a healthy record).
+    assert_eq!(
+        pid_a, pid_b,
+        "both proxies must delegate to the same backing server pid"
+    );
+    assert_eq!(
+        port_a, port_b,
+        "both proxies must delegate to the same backing server port"
+    );
+
+    // A2: exactly one backing `serve --http` process for the workspace --
+    // the assertion the current suite otherwise cannot make. Kills "both
+    // branches spawn".
+    assert_eq!(
+        count_http_children(workspace.path()),
+        1,
+        "exactly one backing `serve --http` process should exist for the workspace"
+    );
+
+    // A3: the discovery record names the same live pid both proxies
+    // reported -- kills a fabricated/stale record.
+    let codanna_dir = workspace.path().join(".codanna");
+    let record = codanna::serve_discovery::read_record(&codanna_dir)
+        .expect("serve.json should exist once both proxies have converged");
+    assert_eq!(
+        record.pid, pid_a,
+        "serve.json pid should match both proxies' reported pid"
+    );
+    assert!(
+        codanna::serve_discovery::pid_is_alive(record.pid),
+        "serve.json pid should still be alive"
+    );
+
+    // A4: the single-flight spawn lock does not outlive the race -- kills
+    // the guard `Drop` never firing.
+    assert!(
+        !codanna_dir.join("http.lock").exists(),
+        "http.lock should not exist once both proxies have settled"
+    );
+}
+
+#[test]
+fn killed_server_is_respawned_and_record_is_updated() {
+    let workspace = prepare_workspace();
+    let _reaper = Reaper(workspace.path().to_path_buf());
+    let codanna_dir = workspace.path().join(".codanna");
+
+    let mut proxy1 = start_proxy(workspace.path());
+    let (pid1, _port1) = await_upstream(&mut proxy1);
+    let _ = proxy1.kill();
+    let _ = proxy1.wait();
+
+    // SIGKILL the backing server directly: this skips its graceful-shutdown
+    // `remove_record` path, so serve.json is left naming a now-dead pid.
+    // That staleness is the scenario under test.
+    kill_pid(pid1);
+    wait_until(
+        || !codanna::serve_discovery::pid_is_alive(pid1),
+        DEADLINE,
+        "backing server pid1 to die after being killed",
+    );
+
+    let stale_record = codanna::serve_discovery::read_record(&codanna_dir)
+        .expect("serve.json should still exist (stale) right after the kill");
+    assert_eq!(
+        stale_record.pid, pid1,
+        "serve.json must still name the killed pid -- confirms the record is genuinely stale, \
+         not already reclaimed"
+    );
+
+    let mut proxy2 = start_proxy(workspace.path());
+    let (pid2, port2) = await_upstream(&mut proxy2);
+    let _ = proxy2.kill();
+    let _ = proxy2.wait();
+
+    // B1: a fresh pid, not the stale one -- kills an impl that returns the
+    // stale record without a liveness check.
+    assert_ne!(
+        pid2, pid1,
+        "respawned backing server must have a different pid than the killed one"
+    );
+
+    // B2 + B3: the record on disk is fully and correctly rewritten to the
+    // new pid/port -- kills an impl that spawns but never rewrites the
+    // record, and kills a partial/torn write.
+    let updated_record = codanna::serve_discovery::read_record(&codanna_dir)
+        .expect("serve.json should exist after respawn");
+    assert_eq!(
+        updated_record.pid, pid2,
+        "serve.json should be updated to the respawned server's pid"
+    );
+    assert_eq!(
+        updated_record.port, port2,
+        "serve.json should be updated to the respawned server's port"
+    );
+    assert!(
+        codanna::serve_discovery::pid_is_alive(pid2),
+        "respawned server pid should be alive"
+    );
+}
+
+/// Connect a real `rmcp` stdio client to `codanna serve --proxy` rooted at
+/// `ws`, mirroring the exact `().serve(TokioChildProcess::new(..))` pattern
+/// `CodeIntelligenceClient::test_server` uses in `src/mcp/client.rs:28-39`,
+/// but pointed at the `--proxy` subcommand (which that helper hardcodes away
+/// from at `client.rs:36`) and returning the connected client instead of
+/// printing to stdout.
+async fn connect_proxy_client(
+    ws: &Path,
+) -> rmcp::service::RunningService<rmcp::service::RoleClient, ()> {
+    use rmcp::service::ServiceExt;
+    use rmcp::transport::{ConfigureCommandExt, TokioChildProcess};
+
+    let test_home = ws.join(".home");
+    std::fs::create_dir_all(&test_home).expect("create test home");
+
+    let ws = ws.to_path_buf();
+    ().serve(
+        TokioChildProcess::new(
+            tokio::process::Command::new(codanna_binary()).configure(|cmd| {
+                cmd.args(["serve", "--proxy"])
+                    .current_dir(&ws)
+                    .env("HOME", &test_home);
+            }),
+        )
+        .expect("spawn codanna serve --proxy as an rmcp child transport"),
+    )
+    .await
+    .expect("rmcp client should complete the stdio initialize handshake with the proxy")
+}
+
+#[tokio::test]
+async fn proxy_serves_real_mcp_traffic_from_shared_upstream() {
+    let workspace = prepare_workspace();
+    let _reaper = Reaper(workspace.path().to_path_buf());
+
+    let client = tokio::time::timeout(DEADLINE, connect_proxy_client(workspace.path()))
+        .await
+        .expect("proxy client should connect within the deadline");
+
+    // C1: the negotiated server name is the UPSTREAM's ("codanna",
+    // server.rs:148), not the proxy's own local `get_info()` fallback
+    // ("codanna-proxy", proxy.rs:176-179). Only reachable if the proxy
+    // actually relayed the upstream's `initialize` response rather than
+    // answering from its own fallback.
+    let server_info = client
+        .peer_info()
+        .expect("proxy should have negotiated peer info during initialize");
+    let server_name = server_info.server_info.name.as_str();
+    assert_eq!(
+        server_name, "codanna",
+        "proxy should relay the upstream server's negotiated name, not answer locally"
+    );
+    assert_ne!(
+        server_name, "codanna-proxy",
+        "proxy must not fall back to its own local get_info() when an upstream is connected"
+    );
+
+    // C2 + C4: a non-empty, real tool list can only originate upstream (the
+    // proxy registers no tools of its own), and this also proves the Bearer
+    // handshake to the backing HTTP server succeeded -- a token mismatch
+    // would 401 at http_server.rs:433 and fail this call outright.
+    let tools = tokio::time::timeout(DEADLINE, client.list_tools(Default::default()))
+        .await
+        .expect("list_tools should complete within the deadline")
+        .expect("list_tools should succeed through the proxy");
+    let tool_names: Vec<&str> = tools.tools.iter().map(|t| t.name.as_ref()).collect();
+    assert!(
+        tool_names.contains(&"find_symbol"),
+        "upstream tool list relayed through the proxy should contain find_symbol, got: {tool_names:?}"
+    );
+    assert!(
+        tool_names.contains(&"search_symbols"),
+        "upstream tool list relayed through the proxy should contain search_symbols, got: {tool_names:?}"
+    );
+
+    // C3: a real find_symbol call against the fixture symbol. The proxy
+    // holds no `IndexFacade` (proxy.rs:8-9), so a match can only come from
+    // the upstream index.
+    let call_result = tokio::time::timeout(
+        DEADLINE,
+        client.call_tool(
+            rmcp::model::CallToolRequestParams::new("find_symbol").with_arguments(
+                serde_json::json!({ "name": "codanna_proxy_e2e_marker" })
+                    .as_object()
+                    .cloned()
+                    .expect("json object literal"),
+            ),
+        ),
+    )
+    .await
+    .expect("call_tool should complete within the deadline")
+    .expect("find_symbol call should succeed through the proxy");
+
+    let found_marker = call_result.content.iter().any(|block| match block {
+        rmcp::model::ContentBlock::Text(text) => text.text.contains("codanna_proxy_e2e_marker"),
+        _ => false,
+    });
+    assert!(
+        found_marker,
+        "find_symbol result relayed through the proxy should name the fixture symbol, got: {:?}",
+        call_result.content
+    );
+
+    client
+        .cancel()
+        .await
+        .expect("proxy client should shut down cleanly");
+}
+
+#[tokio::test]
+async fn second_proxy_shares_one_upstream_one_record_one_pid() {
+    let workspace = prepare_workspace();
+    let _reaper = Reaper(workspace.path().to_path_buf());
+    let codanna_dir = workspace.path().join(".codanna");
+
+    // Proxy #1 spawns the backing server (cold path, WARM path is what
+    // proxy #2 below exercises).
+    let client1 = tokio::time::timeout(DEADLINE, connect_proxy_client(workspace.path()))
+        .await
+        .expect("proxy #1 client should connect within the deadline");
+    let tools1 = tokio::time::timeout(DEADLINE, client1.list_tools(Default::default()))
+        .await
+        .expect("proxy #1 list_tools should complete within the deadline")
+        .expect("proxy #1 list_tools should succeed");
+    assert!(
+        !tools1.tools.is_empty(),
+        "proxy #1 should relay a non-empty tool list from the upstream"
+    );
+
+    let record_before = codanna::serve_discovery::read_record(&codanna_dir)
+        .expect("serve.json should exist once proxy #1 has converged");
+
+    // Proxy #2 starts while the record is already live: this takes the
+    // `Decision::Discover` branch at serve_discovery.rs:406, not the
+    // lock-acquisition path both proxy #1 here and TEST 1 exercise.
+    let client2 = tokio::time::timeout(DEADLINE, connect_proxy_client(workspace.path()))
+        .await
+        .expect("proxy #2 client should connect within the deadline");
+
+    // D1: both proxies' list_tools calls succeed.
+    let tools2 = tokio::time::timeout(DEADLINE, client2.list_tools(Default::default()))
+        .await
+        .expect("proxy #2 list_tools should complete within the deadline")
+        .expect("proxy #2 list_tools should succeed");
+    assert!(
+        !tools2.tools.is_empty(),
+        "proxy #2 should relay a non-empty tool list from the same upstream"
+    );
+
+    let record_after = codanna::serve_discovery::read_record(&codanna_dir)
+        .expect("serve.json should still exist after proxy #2 has converged");
+
+    // D2 + D4: the discovery record is byte-identical before and after
+    // proxy #2 starts -- one record, one pid, one port, not a second spawn.
+    assert_eq!(
+        record_before.pid, record_after.pid,
+        "serve.json pid should be unchanged after the warm-path proxy connects"
+    );
+    assert_eq!(
+        record_before.port, record_after.port,
+        "serve.json port should be unchanged after the warm-path proxy connects"
+    );
+
+    // D3: exactly one backing `serve --http` process for the workspace with
+    // both proxies connected.
+    assert_eq!(
+        count_http_children(workspace.path()),
+        1,
+        "exactly one backing `serve --http` process should exist with both proxies connected"
+    );
+
+    client1
+        .cancel()
+        .await
+        .expect("proxy #1 client should shut down cleanly");
+    client2
+        .cancel()
+        .await
+        .expect("proxy #2 client should shut down cleanly");
+}
+
+/// THE LOAD-BEARING E2E REGRESSION TEST.
+///
+/// Every other fixture in this file uses the default `index_path`, where
+/// `index_path.parent()` and `<workspace_root>/.codanna` happen to be the
+/// same directory -- exactly why the bug this test targets shipped
+/// unnoticed. Before the fix, `serve --http` derived the discovery-record
+/// directory from `config.index_path.parent()` while `discover_or_spawn`
+/// derived it from `workspace_root/.codanna`; under a custom `index_path`
+/// (proven here via `prepare_custom_index_path_workspace`) the two diverge:
+/// the proxy waits in `.codanna` for a record written elsewhere, burns the
+/// full `spawn_timeout_ms`, and leaks an orphan `codanna serve` process.
+#[test]
+fn proxy_discovers_backing_server_with_custom_index_path() {
+    let (workspace, index_container) = prepare_custom_index_path_workspace();
+    // Declared immediately so a failing assertion below still reaps the
+    // backing server via SIGKILL rather than leaking it -- this test is
+    // about orphan processes, so it must not be able to leak one itself.
+    let _reaper = Reaper(workspace.path().to_path_buf());
+
+    let settings = codanna::Settings::default();
+    let spawn_timeout = Duration::from_millis(settings.server.spawn_timeout_ms);
+
+    let started_at = std::time::Instant::now();
+    let mut proxy = start_proxy(workspace.path());
+    let (proxy_pid, _proxy_port) = await_upstream(&mut proxy);
+    let elapsed = started_at.elapsed();
+
+    let _ = proxy.kill();
+    let _ = proxy.wait();
+
+    // (a) the fixed derivation reaches the backing server comfortably inside
+    // `spawn_timeout_ms`. Against the pre-fix `index_path.parent()`
+    // derivation, the proxy waits on the wrong directory for the *entire*
+    // `spawn_timeout_ms` before giving up -- this assertion is what actually
+    // trips on the bug, rather than merely relying on `await_upstream`'s much
+    // longer 30s `DEADLINE` to eventually panic.
+    assert!(
+        elapsed < spawn_timeout,
+        "proxy should reach the backing server well before spawn_timeout_ms ({}ms) elapses \
+         (an index_path-derived discovery dir would burn the full timeout instead); took {elapsed:?}",
+        settings.server.spawn_timeout_ms
+    );
+
+    // (b) the discovery record exists under the WORKSPACE's `.codanna/`,
+    // not wherever the custom index_path happens to live.
+    let codanna_dir = workspace.path().join(".codanna");
+    let record = codanna::serve_discovery::read_record(&codanna_dir).expect(
+        "serve.json should exist under <workspace>/.codanna while the backing server is live",
+    );
+
+    // (c) THE SHADOW-WRITE CHECK. No serve.json exists anywhere under the
+    // custom index_path's directory tree while the server is live. This is
+    // deliberately a separate assertion from (a): (a) alone would still pass
+    // if the record were written to BOTH the correct and the old,
+    // index_path-derived location (a shadow write), since the proxy would
+    // still converge quickly by reading the correct one.
+    assert!(
+        !any_file_named(index_container.path(), "serve.json"),
+        "no serve.json should exist anywhere under the custom index_path's directory while the \
+         server is live -- finding one here means the old index_path-derived discovery dir has \
+         been reintroduced, whether instead of or in addition to the correct one"
+    );
+
+    // (d) the pid the proxy delegates to is the pid recorded on disk.
+    assert_eq!(
+        proxy_pid, record.pid,
+        "the pid the proxy reports delegating to must match the pid in \
+         <workspace>/.codanna/serve.json"
+    );
+
+    // (e) graceful shutdown: SIGINT (not SIGKILL) so the backing server's
+    // `shutdown_signal` future (`ctrl_c()`, src/mcp/http_server.rs) fires and
+    // its `remove_record` cleanup path actually runs, proving serve.json is
+    // removed and no orphan process remains -- not merely that this test's
+    // `Reaper` cleans up after it.
+    interrupt_pid(record.pid);
+
+    wait_until(
+        || codanna::serve_discovery::read_record(&codanna_dir).is_none(),
+        DEADLINE,
+        "serve.json to be removed after graceful shutdown",
+    );
+    wait_until(
+        || !codanna::serve_discovery::pid_is_alive(record.pid),
+        DEADLINE,
+        "backing server process to exit after graceful shutdown",
+    );
+    assert_eq!(
+        count_http_children(workspace.path()),
+        0,
+        "no orphan `serve --http` process should remain for the workspace after graceful shutdown"
+    );
+}
+
+/// THE DIAL-SCHEME PROVENANCE TEST.
+///
+/// Starts a real `codanna serve --https` backing server directly (not via
+/// `discover_or_spawn`/`spawn_detached`, which always spawns `--http` and
+/// must not be touched by this change), waits for its `Https`-scheme
+/// `serve.json` record, then starts a proxy against the SAME workspace and
+/// asserts it discovers and dials that record over `https://` -- never
+/// spawning its own `--http` child as a shortcut.
+#[test]
+#[cfg(feature = "https-server")]
+fn proxy_discovers_and_dials_existing_https_server() {
+    let workspace = prepare_workspace();
+    let _reaper = Reaper(workspace.path().to_path_buf());
+
+    let mut https_server = start_https_server(workspace.path());
+    let record = wait_for_https_record(workspace.path());
+    assert_eq!(
+        record.scheme,
+        codanna::serve_discovery::ServeScheme::Https,
+        "serve.json should record the Https backing server this test started"
+    );
+
+    let mut proxy = start_proxy(workspace.path());
+    let (_upstream_pid, upstream_port, delegating_line) = await_upstream_with_line(&mut proxy);
+
+    let _ = proxy.kill();
+    let _ = proxy.wait();
+
+    // The proxy discovered (not spawned) the existing Https record and
+    // reports delegating to that record's exact port.
+    assert_eq!(
+        upstream_port, record.port,
+        "proxy should report delegating to the discovered Https record's port"
+    );
+
+    // Dial-scheme provenance: the delegation line must name `https://`, not
+    // a hardcoded `http://`.
+    assert!(
+        delegating_line.contains("https://"),
+        "delegation line should report the https:// dial scheme, got: {delegating_line:?}"
+    );
+
+    // THE anti-dead-code check: without this, the cheapest wrong
+    // implementation -- one that ignores `record.scheme` entirely and always
+    // spawns/dials an `--http` child, which would also "work" end-to-end --
+    // passes every assertion above. Confirm no such `--http` child exists for
+    // this workspace at all.
+    assert_eq!(
+        count_http_children(workspace.path()),
+        0,
+        "proxy must not spawn an --http child when an Https backing server is already discoverable"
+    );
+
+    // The Https child must be reaped by SIGKILL like any other backing
+    // server this suite starts.
+    let _ = https_server.kill();
+    let _ = https_server.wait();
+}
+
+/// THE ONLY CHECK A VERIFICATION BYPASS FAILS.
+///
+/// After a real `--https` backing server is up and its cert is persisted,
+/// overwrite the persisted cert with an UNRELATED self-signed PEM (same SANs,
+/// different keypair) before starting the proxy. `serve_tls::pinned_client`
+/// pins trust to whatever PEM is on disk at connect time, so the proxy now
+/// pins the wrong certificate and its TLS handshake against the real backing
+/// server must fail closed -- no delegation line should ever appear. If
+/// `tls_certs_only` were ever replaced with `danger_accept_invalid_certs` (or
+/// any other verification bypass), this is the test that would start passing
+/// when it must not.
+#[test]
+#[cfg(feature = "https-server")]
+fn proxy_refuses_https_when_pinned_cert_does_not_match() {
+    let workspace = prepare_workspace();
+    let _reaper = Reaper(workspace.path().to_path_buf());
+
+    let mut https_server = start_https_server(workspace.path());
+    let record = wait_for_https_record(workspace.path());
+    assert_eq!(record.scheme, codanna::serve_discovery::ServeScheme::Https);
+
+    let cert_path = test_server_cert_path(workspace.path());
+    assert!(
+        cert_path.is_file(),
+        "the https server should have persisted a cert at {cert_path:?} before this test \
+         overwrites it"
+    );
+
+    // Generate an UNRELATED self-signed cert (same SANs as the real one, but
+    // an entirely different keypair) and overwrite the pinned file with it.
+    let unrelated = rcgen::generate_simple_self_signed(vec![
+        "localhost".to_string(),
+        "127.0.0.1".to_string(),
+        "::1".to_string(),
+    ])
+    .expect("generate unrelated self-signed certificate");
+    std::fs::write(&cert_path, unrelated.cert.pem())
+        .expect("overwrite pinned cert with an unrelated certificate");
+
+    let mut proxy = start_proxy(workspace.path());
+
+    // NOTE: the `Proxy: delegating to ...` line prints the discovered
+    // record's scheme/port BEFORE the proxy attempts to actually dial it
+    // (see `serve_proxy` in `src/mcp/proxy.rs`), so its presence alone does
+    // not prove the connection succeeded -- it always prints once discovery
+    // resolves a record, mismatched cert or not. The load-bearing signal for
+    // a fail-closed pinned-cert mismatch is therefore the process's exit
+    // status: `serve_proxy` propagates the TLS/handshake failure as an `Err`
+    // and never reaches `service.waiting()`, so the process exits
+    // non-zero instead of running indefinitely as a working proxy. Drain
+    // stderr on a background thread purely so a full pipe buffer cannot
+    // block the child from exiting.
+    let stderr = proxy
+        .stderr
+        .take()
+        .expect("proxy child stderr should be piped");
+    let collected = Arc::new(Mutex::new(String::new()));
+    let sink = Arc::clone(&collected);
+    thread::spawn(move || {
+        let reader = BufReader::new(stderr);
+        for line in reader.lines().map_while(Result::ok) {
+            if let Ok(mut buf) = sink.lock() {
+                buf.push_str(&line);
+                buf.push('\n');
+            }
+        }
+    });
+
+    // Dropping stdin unblocks the proxy's stdio transport if it is somehow
+    // still waiting on input despite the failed handshake (it should not be).
+    drop(proxy.stdin.take());
+
+    // The proxy must terminate BY ITSELF. Asserting merely `!status.success()`
+    // would be vacuous: the harness SIGKILLs a still-running child at the
+    // deadline, and a killed process is also "not success" --
+    // so a proxy that happily dialed the mismatched cert and kept serving would
+    // be killed by the harness and still satisfy the assertion. A verification
+    // bypass must not be able to pass this test, so require a self-exit.
+    let exit_status = wait_for_self_exit(&mut proxy, DEADLINE);
+    let stderr_text = collected.lock().map(|b| b.clone()).unwrap_or_default();
+
+    let _ = https_server.kill();
+    let _ = https_server.wait();
+
+    let Some(exit_status) = exit_status else {
+        panic!(
+            "proxy kept running against a MISMATCHED pinned certificate -- it must fail closed \
+             and exit. This is what a TLS verification bypass (danger_accept_invalid_certs, or \
+             dropping tls_certs_only) looks like from the outside. stderr:\n{stderr_text}"
+        );
+    };
+    assert!(
+        !exit_status.success(),
+        "proxy exited cleanly despite a mismatched pinned certificate; it must fail closed. \
+         stderr:\n{stderr_text}"
+    );
+
+    // Provenance: it must have exited for the RIGHT reason -- while dialing the
+    // HTTPS upstream -- not from some unrelated startup crash that would also
+    // satisfy the assertions above.
+    //
+    // We deliberately do NOT assert on the words "certificate"/"handshake":
+    // rmcp surfaces the failure as a transport/send error and does not render
+    // rustls's underlying cause in the chain, so the proxy legitimately reports
+    // only `failed to connect ... error sending request for url (https://...)`.
+    // Asserting on wording this error layer never emits would make the test
+    // fail against correct code. What the message DOES prove is that the proxy
+    // dialed the pinned `https://` upstream and could not establish the
+    // connection -- which, combined with the self-exit above, is precisely the
+    // fail-closed behavior a verification bypass cannot produce.
+    let lowered = stderr_text.to_lowercase();
+    assert!(
+        lowered.contains("https://127.0.0.1") && lowered.contains("failed to connect"),
+        "proxy exited non-zero, but its stderr does not show it failing to connect to the \
+         pinned https:// upstream, so this test is not actually observing the pinned-cert \
+         rejection. stderr:\n{stderr_text}"
+    );
+}

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -1,7 +1,13 @@
 // Gateway for CLI-related integration tests
 
+#[path = "cli/support.rs"]
+mod support;
+
 #[path = "cli/test_plugin_commands.rs"]
 mod test_plugin_commands;
 
 #[path = "cli/test_mcp_index_info_remote_status.rs"]
 mod test_mcp_index_info_remote_status;
+
+#[path = "cli/test_serve_proxy_discovery.rs"]
+mod test_serve_proxy_discovery;

--- a/tests/exploration/abi15_grammar_audit/helpers.rs
+++ b/tests/exploration/abi15_grammar_audit/helpers.rs
@@ -1,7 +1,6 @@
 //! Shared helpers for grammar audit tests.
 
 use super::abi15_exploration_common::print_node_tree;
-use codanna::io::format::format_utc_timestamp as get_formatted_timestamp;
 use serde_json::Value;
 use std::collections::{HashMap, HashSet};
 use std::fs;
@@ -222,10 +221,6 @@ fn generate_grammar_analysis(
         "# {name} Grammar Analysis\n\n",
         name = config.language_name
     ));
-    analysis.push_str(&format!(
-        "*Generated: {ts}*\n\n",
-        ts = get_formatted_timestamp()
-    ));
     analysis.push_str("## Statistics\n");
     analysis.push_str(&format!(
         "- Total nodes in grammar JSON: {count}\n",
@@ -325,10 +320,6 @@ pub fn format_node_discovery(
     output.push_str(&format!(
         "=== {name} Language NODE MAPPING ===\n",
         name = config.language_name
-    ));
-    output.push_str(&format!(
-        "  Generated: {ts}\n",
-        ts = get_formatted_timestamp()
     ));
     output.push_str(&format!("  ABI Version: {abi_version}\n"));
     output.push_str(&format!(


### PR DESCRIPTION
## Summary

Adds `codanna serve --proxy`, a stdio↔HTTP delegate that discovers a running backing MCP server for a workspace and spawns one if absent, so multiple MCP clients converge on a single shared backing server instead of each launching its own. Also marks fork builds with a `+rcrsr.N` version so a client can tell which build it is talking to, and removes nondeterministic timestamps from generated parser audit reports.

## Why

An MCP client launched per-editor or per-session would otherwise start a fresh backing server each time, duplicating index state and memory. The proxy lets many stdio clients share one HTTP(S) backing server per workspace. The fork-version work exists so `codanna --version` and the MCP `initialize` handshake identity visibly distinguish this fork from the upstream release it is built on, without disturbing semver precedence.

## Approach / key decisions

- **Discovery protocol** (`src/serve_discovery.rs`): a `ServeRecord {pid, port, scheme}` published as `.codanna/serve.json`, guarded by an `http.lock` `O_EXCL` single-flight so concurrent proxies converge on one backing server rather than racing to spawn duplicates. The record directory is derived from the workspace root (`resolve_workspace_root` + `discovery_dir`) so the writer and reader agree under any custom `index_path`.
- **HTTPS backing servers** participate: `serve --https` now binds its own listener to observe its real port under `--bind :0`, publishes `scheme: https`, and the proxy dials the recorded scheme. HTTPS upstreams are reached through a client pinned to codanna's persisted self-signed cert via `tls_certs_only` — no system roots and no verification bypass. `serve_tls::cert_paths` is the single source of the cert location so writer and pinner cannot drift.
- **Version marker** rides `CARGO_PKG_VERSION` as `+rcrsr.N` build metadata (not a `-rcrsr` pre-release), so the fork compares equal to its upstream base in semver precedence instead of ordering below it.
- **Cargo:** rmcp's `StreamableHttpClient` is implemented for reqwest 0.13, a different crate instance than the direct 0.12 dep, so a renamed `rmcp_reqwest` handle is added with the `rustls-no-provider` TLS feature to avoid a ring + aws-lc-rs provider ambiguity that would panic at runtime.

## Changes

- **Proxy + discovery:** `src/mcp/proxy.rs`, `src/serve_discovery.rs`, `src/serve_tls.rs`, `src/cli/commands/serve.rs`, `src/main.rs`, `src/mcp/{http_server,https_server,mod}.rs`, `src/config/*`.
- **Fork version:** `Cargo.toml`, `Cargo.lock` (`0.9.23+rcrsr.1`).
- **Audit determinism:** dropped the `*Generated:*` wall-clock stamp from parser audit generators (`src/parsing/*/audit.rs`) and regenerated the tracked reports under `contributing/parsers/**`, so a diff appears only when coverage actually changes.
- **Tooling config:** track `.claude/checkmate.json` and `.claude/conduct.json`; ignore `internal/` and `conduct/`.

## Testing

New CLI coverage in `tests/cli/test_serve_proxy_discovery.rs` and supporting helpers exercises discovery, single-flight spawn, and record parsing. Existing MCP index-info and plugin-command tests were updated for the new version string.
