### PR TITLE
feat(typescript): configurable higher-order function-wrapper detection

### DIFF
--- a/src/parsing/typescript/definition.rs
+++ b/src/parsing/typescript/definition.rs
@@ -24,8 +24,25 @@ impl LanguageDefinition for TypeScriptLanguage {
         &["ts", "tsx", "mts", "cts"]
     }
 
-    fn create_parser(&self, _settings: &Settings) -> IndexResult<Box<dyn LanguageParser>> {
-        let parser = TypeScriptParser::new().map_err(|e| IndexError::General(e.to_string()))?;
+    fn create_parser(&self, settings: &Settings) -> IndexResult<Box<dyn LanguageParser>> {
+        let mut parser = TypeScriptParser::new().map_err(|e| IndexError::General(e.to_string()))?;
+        // Wire the configurable function-wrapper list
+        // ([languages.typescript].parser_options.function_wrappers) so
+        // higher-order-wrapped functions (Effect.fn/gen/sync, React memo, etc.)
+        // are indexed as callable functions. Empty by default.
+        if let Some(wrappers) = settings
+            .languages
+            .get("typescript")
+            .and_then(|c| c.parser_options.get("function_wrappers"))
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|x| x.as_str().map(String::from))
+                    .collect::<Vec<_>>()
+            })
+        {
+            parser.set_function_wrappers(wrappers);
+        }
         Ok(Box::new(parser))
     }
 

--- a/src/parsing/typescript/parser.rs
+++ b/src/parsing/typescript/parser.rs
@@ -26,6 +26,11 @@ pub struct TypeScriptParser {
     named_exported_symbols: std::collections::HashSet<String>,
     /// Track JSX component usages (caller -> component name)
     component_usages: Vec<(String, String)>,
+    /// User-declared higher-order function wrappers to treat as function
+    /// definitions, from `[languages.typescript].parser_options.function_wrappers`
+    /// (e.g. `Effect.fn`, `Effect.gen`, `Effect.sync`, `memo`, `forwardRef`).
+    /// Empty by default: the feature ships knowing zero frameworks.
+    function_wrappers: Vec<String>,
 }
 
 impl TypeScriptParser {
@@ -131,7 +136,14 @@ impl TypeScriptParser {
             default_exported_symbols: std::collections::HashSet::new(),
             named_exported_symbols: std::collections::HashSet::new(),
             component_usages: Vec::new(),
+            function_wrappers: Vec::new(),
         })
+    }
+
+    /// Set the configurable higher-order function-wrapper names, from
+    /// `[languages.typescript].parser_options.function_wrappers`.
+    pub fn set_function_wrappers(&mut self, wrappers: Vec<String>) {
+        self.function_wrappers = wrappers;
     }
 
     /// Extract symbols from a TypeScript node
@@ -828,8 +840,28 @@ impl TypeScriptParser {
                                 false
                             };
 
+                        // Detect higher-order-wrapped function definitions such as
+                        // `const x = Effect.fn("name")(function* () {})`,
+                        // `const x = Effect.gen(function* () {})`, or a service wrapper
+                        // `const make = Effect.sync(() => { ... })`. The binding names a
+                        // function/scope even though its value is a call expression.
+                        let wrapped_function = if is_arrow_function {
+                            None
+                        } else {
+                            child.child_by_field_name("value").and_then(|value_node| {
+                                Self::find_wrapped_function(
+                                    value_node,
+                                    code,
+                                    &self.function_wrappers,
+                                    0,
+                                )
+                            })
+                        };
+
+                        let is_function = is_arrow_function || wrapped_function.is_some();
+
                         // Determine the kind based on whether it's a function or regular variable
-                        let kind = if is_arrow_function {
+                        let kind = if is_function {
                             SymbolKind::Function
                         } else if code[node.byte_range()].starts_with("const") {
                             SymbolKind::Constant
@@ -859,8 +891,9 @@ impl TypeScriptParser {
                             visibility,
                         );
 
-                        // Override scope context for arrow functions - they are never hoisted
-                        if is_arrow_function {
+                        // Override scope context for arrow functions and wrapped
+                        // functions - neither is hoisted
+                        if is_function {
                             // Arrow functions are not hoisted, but keep the parent context that was already set
                             match symbol.scope_context {
                                 Some(crate::symbol::ScopeContext::Local {
@@ -935,10 +968,101 @@ impl TypeScriptParser {
                                 }
                             }
                         }
+
+                        // Process the wrapped function's body (Effect.fn/gen generator, or
+                        // an Effect.sync/suspend arrow service wrapper) so nested symbols and
+                        // calls inside it are indexed, mirroring the arrow-function path.
+                        if let Some(inner) = wrapped_function {
+                            if let Some(body) = inner.child_by_field_name("body") {
+                                let saved_function =
+                                    self.context.current_function().map(|s| s.to_string());
+                                let saved_class =
+                                    self.context.current_class().map(|s| s.to_string());
+
+                                self.context.enter_scope(ScopeType::function());
+                                self.context.set_current_function(Some(name.to_string()));
+
+                                self.register_handled_node(body.kind(), body.kind_id());
+                                self.extract_symbols_from_node(
+                                    body,
+                                    code,
+                                    file_id,
+                                    counter,
+                                    symbols,
+                                    module_path,
+                                    depth + 1,
+                                );
+
+                                self.context.exit_scope();
+                                self.context.set_current_function(saved_function);
+                                self.context.set_current_class(saved_class);
+                            }
+                        }
                     }
                 }
             }
         }
+    }
+
+    /// Extract the dotted callee name of a wrapping call: `memo`, `Effect.sync`,
+    /// or (curried) the inner callee of `Effect.fn("x")(...)` -> `Effect.fn`.
+    fn wrapper_name<'a>(callee: Node, code: &'a str) -> Option<&'a str> {
+        match callee.kind() {
+            "identifier" | "member_expression" => Some(&code[callee.byte_range()]),
+            "call_expression" => callee
+                .child_by_field_name("function")
+                .and_then(|f| Self::wrapper_name(f, code)),
+            _ => None,
+        }
+    }
+
+    /// Detect a user-declared higher-order-wrapped function definition. `wrappers`
+    /// is the configurable `[languages.typescript].parser_options.function_wrappers`
+    /// list (e.g. `Effect.fn`, `Effect.gen`, `Effect.sync`, `memo`, `forwardRef`).
+    /// Returns the inner function/arrow/generator node when the value is a call
+    /// (or a curried chain of calls) whose callee name is in that list. An empty
+    /// list disables detection entirely, so the feature is fully opt-in and ships
+    /// knowing zero frameworks - ordinary calls like `arr.map(x => ...)` are only
+    /// ever matched if the user explicitly lists `arr.map`, which they would not.
+    fn find_wrapped_function<'tree>(
+        node: Node<'tree>,
+        code: &str,
+        wrappers: &[String],
+        depth: usize,
+    ) -> Option<Node<'tree>> {
+        if depth > 3 || wrappers.is_empty() || node.kind() != "call_expression" {
+            return None;
+        }
+
+        let is_configured = node
+            .child_by_field_name("function")
+            .and_then(|c| Self::wrapper_name(c, code))
+            .map(|name| wrappers.iter().any(|w| w == name))
+            .unwrap_or(false);
+
+        if is_configured {
+            if let Some(args) = node.child_by_field_name("arguments") {
+                let mut cursor = args.walk();
+                for arg in args.named_children(&mut cursor) {
+                    if matches!(
+                        arg.kind(),
+                        "generator_function" | "arrow_function" | "function_expression"
+                    ) {
+                        return Some(arg);
+                    }
+                }
+            }
+        }
+
+        // Curried wrappers like `Effect.fn("name")(gen)` where the callee is
+        // itself a call expression.
+        if let Some(callee) = node.child_by_field_name("function") {
+            if callee.kind() == "call_expression" {
+                return Self::find_wrapped_function(callee, code, wrappers, depth + 1);
+            }
+        }
+
+        None
     }
 
     /// Process arrow functions
@@ -1635,6 +1759,23 @@ impl TypeScriptParser {
                 } else {
                     current_function
                 }
+            } else {
+                current_function
+            }
+        } else if node.kind() == "variable_declarator"
+            && node
+                .child_by_field_name("value")
+                .and_then(|v| Self::find_wrapped_function(v, code, &self.function_wrappers, 0))
+                .is_some()
+        {
+            // Higher-order-wrapped functions (`const x = Effect.fn(...)(function* () {})`,
+            // `const make = Effect.sync(() => {...})`) name a function scope at ANY
+            // nesting level. The real service pattern nests domain functions inside an
+            // outer `Effect.sync` wrapper, so a call made in a sibling wrapped function
+            // must attribute to that sibling, not the outer wrapper. Unlike plain arrow
+            // consts below, this is NOT gated on top level.
+            if let Some(name_node) = node.child_by_field_name("name") {
+                Some(&code[name_node.byte_range()])
             } else {
                 current_function
             }

--- a/tests/parsers/typescript/test_function_wrappers.rs
+++ b/tests/parsers/typescript/test_function_wrappers.rs
@@ -1,0 +1,151 @@
+//! Tests for configurable higher-order function-wrapper detection.
+//!
+//! Some TypeScript codebases define functions through a higher-order wrapper
+//! rather than a plain declaration, e.g. `const load = wrap(function* () {})`
+//! or `const View = memo(() => {})`. Because the binding's value is a call
+//! expression, the parser cannot know it is a function without being told which
+//! wrappers to treat that way. The `[languages.typescript].parser_options`
+//! `function_wrappers` list supplies those callee names. It is empty by default,
+//! so this behavior is fully opt-in and ships knowing no framework.
+
+#[cfg(test)]
+mod tests {
+    use codanna::parsing::LanguageParser;
+    use codanna::parsing::typescript::TypeScriptParser;
+    use codanna::types::{FileId, SymbolCounter, SymbolKind};
+
+    fn parse_with_wrappers(code: &str, wrappers: &[&str]) -> Vec<codanna::Symbol> {
+        let mut parser = TypeScriptParser::new().expect("Failed to create parser");
+        parser.set_function_wrappers(wrappers.iter().map(|w| w.to_string()).collect());
+        let file_id = FileId::new(1).unwrap();
+        let mut counter = SymbolCounter::new();
+        parser.parse(code, file_id, &mut counter)
+    }
+
+    fn kind_of<'a>(symbols: &'a [codanna::Symbol], name: &str) -> Option<&'a SymbolKind> {
+        symbols
+            .iter()
+            .find(|s| s.name.as_ref() == name)
+            .map(|s| &s.kind)
+    }
+
+    /// A generator-wrapped binding (`const x = wrap(function* () {})`) is
+    /// registered as a Function when its wrapper is configured.
+    #[test]
+    fn test_generator_wrapper_registers_function() {
+        let code = r#"
+const loadThing = trackedFn("loadThing")(function* (id: string) {
+    return id;
+});
+"#;
+        let symbols = parse_with_wrappers(code, &["trackedFn"]);
+        assert_eq!(
+            kind_of(&symbols, "loadThing"),
+            Some(&SymbolKind::Function),
+            "a generator-wrapped binding with a configured wrapper should be a Function"
+        );
+    }
+
+    /// Control: with no wrappers configured the same binding is NOT a function.
+    /// This proves the feature is opt-in and bakes in no framework knowledge.
+    #[test]
+    fn test_no_wrappers_is_stock_behavior() {
+        let code = r#"
+const loadThing = trackedFn("loadThing")(function* (id: string) {
+    return id;
+});
+"#;
+        let symbols = parse_with_wrappers(code, &[]);
+        assert_ne!(
+            kind_of(&symbols, "loadThing"),
+            Some(&SymbolKind::Function),
+            "with no configured wrappers, a wrapped binding must not be treated as a function"
+        );
+    }
+
+    /// An arrow-bodied wrapper (`const make = wrap(() => { ... })`) is descended,
+    /// so functions declared inside its body are indexed too. Arrows are only
+    /// descended when the wrapper is configured, which is what keeps ordinary
+    /// callbacks such as `arr.map(x => ...)` from being treated as definitions.
+    #[test]
+    fn test_arrow_wrapper_body_is_descended() {
+        let code = r#"
+const makeService = provide(() => {
+    const inner = trackedFn("inner")(function* () {
+        return 1;
+    });
+    return { inner };
+});
+"#;
+        let symbols = parse_with_wrappers(code, &["provide", "trackedFn"]);
+        assert_eq!(
+            kind_of(&symbols, "makeService"),
+            Some(&SymbolKind::Function),
+            "the arrow-bodied wrapper binding should be a Function"
+        );
+        assert_eq!(
+            kind_of(&symbols, "inner"),
+            Some(&SymbolKind::Function),
+            "a function nested inside the descended wrapper body should be indexed"
+        );
+    }
+
+    /// The mechanism is framework-neutral: a plain identifier wrapper such as
+    /// React's `memo` works the same way.
+    #[test]
+    fn test_identifier_wrapper_is_generic() {
+        let code = r#"
+const UserCard = memo(() => {
+    return null;
+});
+"#;
+        let symbols = parse_with_wrappers(code, &["memo"]);
+        assert_eq!(
+            kind_of(&symbols, "UserCard"),
+            Some(&SymbolKind::Function),
+            "a binding wrapped by a configured identifier wrapper should be a Function"
+        );
+    }
+
+    /// A call whose callee is NOT in the list is never treated as a definition,
+    /// even though it passes an arrow argument. Guards against false positives.
+    #[test]
+    fn test_unlisted_call_is_not_a_function() {
+        let code = r#"
+const ids = users.map((u) => u.id);
+"#;
+        let symbols = parse_with_wrappers(code, &["memo"]);
+        assert_ne!(
+            kind_of(&symbols, "ids"),
+            Some(&SymbolKind::Function),
+            "an ordinary call (users.map) must not be treated as a function definition"
+        );
+    }
+
+    /// Calls made inside a wrapped function are attributed to that function, so
+    /// caller/callee tracking works for wrapped definitions.
+    #[test]
+    fn test_calls_inside_wrapper_are_attributed() {
+        let code = r#"
+const loadThing = trackedFn("loadThing")(function* (id: string) {
+    return id;
+});
+
+const useThing = trackedFn("useThing")(function* () {
+    const value = yield* loadThing("x");
+    return value;
+});
+"#;
+        let mut parser = TypeScriptParser::new().expect("Failed to create parser");
+        parser.set_function_wrappers(vec!["trackedFn".to_string()]);
+        let calls = parser.find_calls(code);
+
+        let attributed = calls
+            .iter()
+            .any(|(caller, called, _)| *caller == "useThing" && *called == "loadThing");
+        assert!(
+            attributed,
+            "a call inside a wrapped function should be attributed to it (useThing -> loadThing); got: {calls:?}"
+        );
+    }
+}

--- a/tests/parsers_tests.rs
+++ b/tests/parsers_tests.rs
@@ -10,6 +10,9 @@ mod test_typescript_resolution_pipeline;
 #[path = "parsers/typescript/test_call_tracking.rs"]
 mod test_typescript_call_tracking;
 
+#[path = "parsers/typescript/test_function_wrappers.rs"]
+mod test_typescript_function_wrappers;
+
 #[path = "parsers/typescript/test_nested_functions.rs"]
 mod test_typescript_nested_functions;
 


### PR DESCRIPTION
## Description

Adds opt-in detection of higher-order-wrapped function definitions in TypeScript.

Today a `const` is registered as a function only when its value is a direct arrow or function expression. When the value is instead a call, such as `const View = memo(() => {})` or `const load = wrap(function* () {})`, it is recorded as a `Constant`, so `find_symbol` / `find_callers` / `get_calls` / `analyze_impact` return nothing for it even though it is called by name across the codebase.

This change lets users declare the wrapper callee names via the existing (previously unused for TypeScript) `LanguageConfig.parser_options` bag:

```toml
[languages.typescript.parser_options]
function_wrappers = ["memo", "forwardRef", "create", "wrap"]
```

When a `const` binding's value is a call (or curried call, e.g. `wrap("name")(fn)`) whose callee name is in that list, the binding is registered as a `Function` and the wrapped generator/arrow/function body is descended so nested symbols and calls are indexed. The list is **empty by default**, so existing behavior is unchanged unless a user opts in, and no framework is hardcoded.

Fixes #115

### How it works

- `wrapper_name` / `find_wrapped_function` (parser.rs): return the inner generator/arrow/function-expression node when a call's callee name is in the configured list. An empty list always returns `None`, i.e. stock behavior.
- `process_variable_declaration` (parser.rs): registers a matched binding as a `Function` and descends its body for nested symbols.
- `extract_calls_recursive` (parser.rs): attributes calls made inside a wrapped body to the wrapped function, at any nesting depth.
- `definition.rs`: reads `function_wrappers` from settings and sets it on the parser (the registry parse path).

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

- [x] Tests pass locally
- [x] Added new tests
- [x] Performance verified

New `tests/parsers/typescript/test_function_wrappers.rs` (6 tests):

- generator wrapper registers a `Function`
- empty list is stock behavior (the control: proves the feature is opt-in and bakes in nothing)
- arrow-bodied wrapper body is descended (nested functions indexed)
- generic identifier wrapper works (React `memo`), showing the mechanism is framework-neutral
- an unlisted call (`users.map(...)`) is not treated as a function (false-positive guard)
- calls inside a wrapper are attributed to it

`cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test` all pass locally.

Performance: detection only runs on `const` declarations whose value is a `call_expression`, and returns immediately when the wrapper list is empty (the default), so there is no measurable impact on existing indexing.

## Checklist

- [x] Code follows guidelines
- [x] Self-reviewed
- [x] Documentation updated (config example + doc comments)
- [x] No new warnings
