### PR TITLE
fix(storage): wait for merges on commit so segments do not accumulate

### DIFF
--- a/src/storage/tantivy/writer.rs
+++ b/src/storage/tantivy/writer.rs
@@ -141,6 +141,11 @@ impl DocumentIndex {
                 }
             }
 
+            // Block until this commit's merges finish. Dropping the writer here
+            // instead (the previous behaviour) kills the merge threads commit
+            // just spawned, so every commit's segment survives forever.
+            writer.wait_merging_threads()?;
+
             // Reload the reader to see new documents
             self.reader.reload()?;
 


### PR DESCRIPTION
`commit_batch` takes the `IndexWriter` out of the lock, commits, and lets it drop at the end of the block. Tantivy runs merges on threads owned by the writer, so dropping it there kills the merges that `commit()` just scheduled. Every commit's segment survives, and nothing ever collapses them.

Under `serve --watch` that means one new segment per commit, forever.

## Repro

400 TypeScript files, `embedding_threads = 1`, watched by `codanna serve --http --watch`. Twelve rounds of in-place edits — same symbol names, changed values — so content churns while the symbol count stays constant.

|                            | v0.13.2                  | with this patch    |
| -------------------------- | ------------------------ | ------------------ |
| segments                   | 14 → **1053**            | 4 → **5**          |
| index on disk              | 16 MB → **224 MB**       | 5 MB → **29 MB**   |
| RSS after 12 rounds        | 1479 MB, still climbing  | 1251 MB, flat      |
| RSS slope, rounds 4-12     | **+18.0 MB/round**       | **+6.4 MB/round**  |

A real ~3,900-file checkout that had been served for a few days was sitting at 322 segments / 123 MB.

## Full index builds are not slower

|  files | build     | time      | segments | size      |
| ------ | --------- | --------- | -------- | --------- |
|    400 | v0.13.2   | 16.1s     | 11       | 9 MB      |
|    400 | patched   | **12.9s** | **4**    | **4 MB**  |
|   1500 | v0.13.2   | 48.0s     | 19       | 44 MB     |
|   1500 | patched   | **47.6s** | **4**    | **13 MB** |

Waiting on merges costs CPU, but every stage downstream then touches far fewer files, so it comes out even or ahead.

## Change

One call, after the commit succeeds and before the reader reloads, so the reader picks up merged segments.
