### PR TITLE
fix: prevent unresolved imports from capturing unrelated exports

### DIFF
--- a/src/indexing/pipeline/stages/resolve.rs
+++ b/src/indexing/pipeline/stages/resolve.rs
@@ -208,6 +208,15 @@ impl ResolveStage {
             }
         }
 
+        // An unresolved import owns the bare name. It cannot fall through
+        // to a same-named export elsewhere in the index. Local scope above
+        // still takes precedence, and receiver calls keep their own resolution.
+        if Self::is_bare_instance_call(unresolved)
+            && context.scope.is_external_import(&unresolved.to_name)
+        {
+            return None;
+        }
+
         // Inheritance witness for bare calls inside a class body, only
         // where the language vouches that a bare name can dispatch to an
         // instance member. Runs after the scope lookup — file-local and

--- a/tests/unresolved_import.rs
+++ b/tests/unresolved_import.rs
@@ -1,0 +1,83 @@
+use std::{fs, path::Path, process::Command};
+
+fn run(root: &Path, args: &[&str]) -> String {
+    let output = Command::new(env!("CARGO_BIN_EXE_codanna"))
+        .current_dir(root)
+        .args(args)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8(output.stdout).unwrap()
+}
+
+#[test]
+fn deleted_import_does_not_capture_another_roots_export() {
+    for extension in ["ts", "js"] {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().canonicalize().unwrap();
+        fs::create_dir(root.join(".codanna")).unwrap();
+        fs::write(root.join(".codanna/settings.toml"), format!(
+            "workspace_root = {}\n[indexing]\nindexed_paths = [\"repo_a\", \"repo_b\"]\n[semantic_search]\nenabled = false\n",
+            serde_json::to_string(&root).unwrap()
+        )).unwrap();
+        for repo in ["repo_a", "repo_b"] {
+            fs::create_dir(root.join(repo)).unwrap();
+            fs::write(
+                root.join(repo).join(format!("target.{extension}")),
+                "export function sharedTarget() { return 42; }\n",
+            )
+            .unwrap();
+        }
+        fs::write(root.join("repo_a").join(format!("caller.{extension}")),
+            "import { sharedTarget } from './target';\nexport function entry() { return sharedTarget(); }\nexport const arrowEntry = () => sharedTarget();\n").unwrap();
+        run(&root, &["index", "--no-progress"]);
+        let edges = run(&root, &["dump", "--edges", "--relation", "calls"]);
+        let calls: Vec<_> = edges
+            .lines()
+            .filter_map(|line| serde_json::from_str::<serde_json::Value>(line).ok())
+            .filter(|row| {
+                row["type"] == "result"
+                    && matches!(
+                        row["data"]["from"]["name"].as_str(),
+                        Some("entry" | "arrowEntry")
+                    )
+            })
+            .collect();
+        let callers: std::collections::BTreeSet<_> = calls
+            .iter()
+            .map(|row| row["data"]["from"]["name"].as_str().unwrap())
+            .collect();
+        assert_eq!(
+            callers,
+            ["entry", "arrowEntry"].into_iter().collect(),
+            "valid {extension} imports must resolve"
+        );
+        for row in calls {
+            assert!(
+                row["data"]["to"]["file_path"]
+                    .as_str()
+                    .unwrap()
+                    .contains("repo_a/target")
+            );
+        }
+        fs::remove_file(root.join("repo_a").join(format!("target.{extension}"))).unwrap();
+        for args in [
+            vec!["index", "--no-progress"],
+            vec!["index", "--force", "--no-progress"],
+        ] {
+            run(&root, &args);
+            let edges = run(&root, &["dump", "--edges", "--relation", "calls"]);
+            assert!(
+                !edges
+                    .lines()
+                    .filter_map(|line| serde_json::from_str::<serde_json::Value>(line).ok())
+                    .any(|row| row["type"] == "result"),
+                "unresolved {extension} import must not capture repo_b: {edges}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Description
Fixes #122. An unresolved bare import now stops before global name fallback, preventing a deleted target from capturing another repository's export. Existing local-scope resolution retains precedence.

## Type of Change
- [x] Bug fix

## Testing
- [x] Regression covers TypeScript and JavaScript, regular and arrow callers, incremental deletion and force rebuild.
- [x] `quick-check.sh` and `full-test.sh` pass.
- [x] No index-format or API changes; the added check is an import-binding lookup on bare calls.

## Checklist
- [x] Guidelines followed; self-reviewed.
- [x] No new warnings.
