### PR TITLE
fix: remove the resolution cache symbol limit

### DIFF
--- a/src/indexing/pipeline/types.rs
+++ b/src/indexing/pipeline/types.rs
@@ -879,13 +879,16 @@ impl SymbolLookupCache {
     /// For bulk indexing, prefer building the cache during INDEX stage.
     pub fn from_index(index: &crate::storage::DocumentIndex) -> PipelineResult<Self> {
         // Get total count to pre-allocate
-        let count = index.document_count().unwrap_or(0) as usize;
+        let count = index
+            .count_symbols()
+            .map_err(|e| PipelineError::Index(crate::IndexError::Storage(e)))?;
         let cache = Self::with_capacity(count);
+        if count == 0 {
+            return Ok(cache);
+        }
 
-        // Load all symbols from Tantivy
-        // Use a large limit to get all symbols
         let symbols = index
-            .get_all_symbols(1_000_000)
+            .get_all_symbols(count)
             .map_err(|e| PipelineError::Index(crate::IndexError::Storage(e)))?;
 
         for symbol in symbols {

--- a/tests/cache_population.rs
+++ b/tests/cache_population.rs
@@ -1,0 +1,38 @@
+use codanna::{
+    FileId, Range, Symbol, SymbolId, SymbolKind, config::Settings,
+    indexing::pipeline::types::SymbolLookupCache, storage::DocumentIndex,
+};
+
+fn check_cache(count: u32) {
+    let dir = tempfile::tempdir().unwrap();
+    let index = DocumentIndex::new(dir.path(), &Settings::default()).unwrap();
+    index.start_batch().unwrap();
+    for id in 1..=count {
+        let symbol = Symbol::new(
+            SymbolId::new(id).unwrap(),
+            "generated",
+            SymbolKind::Function,
+            FileId::new(1).unwrap(),
+            Range::new(id, 0, id, 1),
+        );
+        index.add_document(&symbol, "generated.rs").unwrap();
+    }
+    index.commit_batch().unwrap();
+    let cache = SymbolLookupCache::from_index(&index).unwrap();
+    assert_eq!(cache.len(), count as usize);
+    for id in 1..=count {
+        assert!(cache.get_ref(SymbolId::new(id).unwrap()).is_some());
+    }
+}
+
+#[test]
+fn cache_contains_every_persisted_symbol() {
+    check_cache(0);
+    check_cache(7);
+}
+
+#[test]
+#[ignore = "writes one million synthetic symbols; run explicitly for the former cache limit"]
+fn cache_exceeds_one_million_symbols() {
+    check_cache(1_000_001);
+}


### PR DESCRIPTION
## Description
Fixes #123. Size the resolution-cache load from the exact persisted symbol count instead of a one-million-symbol cap. Empty indexes return without issuing a zero-limit query; count errors propagate.

## Type of Change
- [x] Bug fix

## Testing
- [x] Empty and small cache-content tests.
- [x] Opt-in 1,000,001-symbol regression fails before and passes after the fix (59 seconds in release mode).
- [x] `quick-check.sh` and `full-test.sh` pass.

## Checklist
- [x] Guidelines followed; self-reviewed; no new warnings.
- [x] No index-format or API changes.

The existing retrieval order is preserved. Memory now scales with the complete symbol population; existing indexes need a rebuild to recover previously omitted relationships.
